### PR TITLE
Support for high-density DIO modules (issues with memory indexing for slave PDOs > 8)

### DIFF
--- a/src/EtherCAT.NET/Infrastructure/DigitalIn.cs
+++ b/src/EtherCAT.NET/Infrastructure/DigitalIn.cs
@@ -42,9 +42,10 @@ namespace EtherCAT.NET.Infrastructure
                 // get slave variable in order to set bit offset
                 SlaveVariable slaveVariable = _slavePdos[channel - 1].Variables.First();
                 int bitOffset = slaveVariable.BitOffset;
+                int* memptr = ((int*)slaveVariable.DataPtr);
 
-                int channelInput = _memoryMapping[0] & (1 << bitOffset);
-                channelSet = BitConverter.ToBoolean(channelInput.ToByteArray(), 0);
+                int channelInput = memptr[0] & (1 << bitOffset);
+                channelSet = BitConverter.ToBoolean(channelInput.ToByteArray(), (int)(bitOffset / 8));
             }
 
             return channelSet;

--- a/src/EtherCAT.NET/Infrastructure/DigitalOut.cs
+++ b/src/EtherCAT.NET/Infrastructure/DigitalOut.cs
@@ -27,13 +27,14 @@ namespace EtherCAT.NET.Infrastructure
                 // get slave variable in order to set bit offset
                 SlaveVariable slaveVariable = _slavePdos[channel - 1].Variables.First();
                 int bitOffset = slaveVariable.BitOffset;
+                int* memptr = ((int*)slaveVariable.DataPtr);
 
                 if (value)
                     // set channel bit
-                    _memoryMapping[0] |= 1 << bitOffset;
+                    memptr[0] |= 1 << bitOffset;
                 else
                     // clear channel bit
-                    _memoryMapping[0] &= ~(1 << bitOffset);  
+                    memptr[0] &= ~(1 << bitOffset);  
             }
 
             return validChannel;
@@ -51,7 +52,8 @@ namespace EtherCAT.NET.Infrastructure
             {
                 // get slave variable in order to set bit offset
                 SlaveVariable slaveVariable = _slavePdos[channel - 1].Variables.First();
-                _memoryMapping[0] ^= 1 << slaveVariable.BitOffset;
+                int* memptr = ((int*)slaveVariable.DataPtr);
+                memptr[0] ^= 1 << slaveVariable.BitOffset;
             }
 
             return validChannel;


### PR DESCRIPTION
The DigitalIn and DigitalOut wrappers have an issue when calculating the correct memory address for IO modules having >8 In/Outputs. By explicity using the slaveVariable's memory base address, the modified code now writes the modified bits to the correct byte in memory.
Quick example using a Beckhoff el2809 16Bit DO module:
//sample code as provided in sample project up to line 180
var el2809_out = new DigitalOut(slaves[1]);
el2809_out.SetChannel(9, false); //used to write to channel 2 before change
//continued sample code as provided in sample project 

[issue detected and fix tested on win10 x64 and x32, Linux with dotnetcore/mono might behave differently (although it shouldn't)]