### PR TITLE
Fix some issues and enable ARM architecture build

### DIFF
--- a/init_solution.ps1
+++ b/init_solution.ps1
@@ -1,45 +1,154 @@
 Write-Host "Updating Git submodule."
 git submodule update --init --recursive --quiet
 
-# x86
-Write-Host "Creating native x86 project."
-$path = "$($PSScriptRoot)/artifacts/bin32"
-New-Item -Force -ItemType directory -Path $path
+# load .NET types
+$RType = [type]::GetType('System.Runtime.InteropServices.RuntimeInformation, System.Runtime.InteropServices.RuntimeInformation')
+$PType = [type]::GetType('System.Runtime.InteropServices.OSPlatform, System.Runtime.InteropServices.RuntimeInformation')
+
+try
+{
+    if (-not $RType -or -not $PType) { throw }
+
+    $R = $RType
+    $P = $PType
+
+    $mWindows = $R::IsOSPlatform($P::Windows)
+    $mLinux   = $R::IsOSPlatform($P::Linux)
+    $mMacOS   = $R::IsOSPlatform($P::OSX)
+}
+catch
+{
+    # fallback for Windows PowerShell 5.1 oder missing types
+    $mWindows = $env:OS -eq 'Windows_NT'
+    $mLinux   = $false
+    $mMacOS   = $false
+}
+
+Write-Host "Windows: $mWindows, Linux: $mLinux, macOS: $mMacOS"
+
+# detect architecture once
+# try .NET Core API first (PowerShell Core on Linux/macOS)
+$type = [type]::GetType('System.Runtime.InteropServices.RuntimeInformation, System.Runtime.InteropServices.RuntimeInformation')
+
+if ($type)
+{
+    # RuntimeInformation exists
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+}
+else
+{
+    # Fallback for Windows PowerShell / older .NET
+    switch ($env:PROCESSOR_ARCHITECTURE) {
+        'AMD64' { $arch = 'X64'    }
+        'x86'   { $arch = 'X86'    }
+        'ARM64' { $arch = 'Arm64'  }
+        'ARM'   { $arch = 'Arm'    }
+        default { $arch = $env:PROCESSOR_ARCHITECTURE }
+    }
+}
+
+Write-Host "Detected architecture: $arch"
+
+# x86 / arm
+if ($arch -like 'Arm*')
+{
+    Write-Host "Creating native arm project."
+    $path = "$($PSScriptRoot)/artifacts/arm32"
+} else
+{
+    Write-Host "Creating native x86 project."
+    $path = "$($PSScriptRoot)/artifacts/bin32"
+}
+
+New-Item -Force -ItemType Directory -Path $path | Out-Null
 Set-Location -Path $path
 
-if ($IsWindows)
+if ($mWindows)
 {
-	cmake ./../../native -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" -G "Visual Studio 16 2019" -A "Win32"
+	cmake ./../../native `
+        -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" `
+        -G "Visual Studio 16 2019" `
+        -A "Win32"
 }
-elseif ($IsLinux)
+elseif ($mLinux)
 {
-    cmake ./../../native -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
+    if ($arch -like 'Arm*')
+    {
+        # For 32-bit ARM, install the following compilers:
+        # sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+
+        cmake ./../../native `
+            -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc `
+            -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow' `
+            -DCMAKE_CXX_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow'
+    }
+    else
+    {
+        cmake ./../../native `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS=-m32 `
+            -DCMAKE_CXX_FLAGS=-m32 `
+            -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
+    }
 }
-elseif ($IsMacOS)
+elseif ($mMacOS)
 {
     # The i386 architecture is deprecated for macOS
     throw [System.PlatformNotSupportedException]
 }
-else 
+else
 {
     throw [System.PlatformNotSupportedException]
 }
 
-# x64
-Write-Host "Creating native x64 project."
-$path = "$($PSScriptRoot)/artifacts/bin64"
+# x64 / arm4
+if ($arch -like 'Arm*')
+{
+    Write-Host "Creating native arm64 project."
+    $path = "$($PSScriptRoot)/artifacts/arm64"
+} else
+{
+    Write-Host "Creating native x64 project."
+    $path = "$($PSScriptRoot)/artifacts/bin64"
+}
+
 New-Item -Force -ItemType directory -Path $path
 Set-Location -Path $path
 
-if ($IsWindows)
+if ($mWindows)
 {
-	cmake ./../../native -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" -G "Visual Studio 16 2019" -A "x64"
+	cmake ./../../native `
+        -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" `
+        -G "Visual Studio 16 2019" `
+        -A "x64"
 }
-elseif ($IsLinux -or $IsMacOS)
+elseif ($mLinux)
 {
-    cmake ./../../native -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m64 -DCMAKE_CXX_FLAGS=-m64
+    if ($arch -like 'Arm*')
+    {
+        cmake ./../../native `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow' `
+            -DCMAKE_CXX_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow'
+    }
+    else
+    {
+        cmake ./../../native `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS=-m64 `
+            -DCMAKE_CXX_FLAGS=-m64
+    }
 }
-else 
+elseif ($mMacOS)
+{
+    cmake ./../../native `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DCMAKE_C_FLAGS=-m64 `
+        -DCMAKE_CXX_FLAGS=-m64
+}
+else
 {
     throw [System.PlatformNotSupportedException]
 }

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -55,6 +55,9 @@ namespace EtherCAT.NET
         private Task _watchdogTask;
         private bool _watchDogActive = true;
 
+        // sdo callbacks
+        List<EcHL.PO2SOCallback> _callbacks = new List<EcHL.PO2SOCallback>();
+
         #endregion
 
         #region Constructors
@@ -118,8 +121,6 @@ namespace EtherCAT.NET
 
         private void ConfigureSlaves(IList<SlaveInfo> slaves)
         {
-            var callbacks = new List<EcHL.PO2SOCallback>();
-
             foreach (var slave in slaves)
             {
                 // SDO / PDO config / PDO assign
@@ -128,24 +129,22 @@ namespace EtherCAT.NET
 
                 var sdoWriteRequests = slave.GetConfiguration(extensions).ToList();
 
-                EcHL.PO2SOCallback callback = slaveIndex =>
+                if (sdoWriteRequests.Count != 0)
                 {
-                    sdoWriteRequests.ToList().ForEach(sdoWriteRequest =>
+                    EcHL.PO2SOCallback callback = slaveIndex =>
                     {
-                        EcUtilities.CheckErrorCode(this.Context, EcUtilities.SdoWrite(this.Context, slaveIndex, sdoWriteRequest.Index, sdoWriteRequest.SubIndex, sdoWriteRequest.Dataset), nameof(EcHL.SdoWrite));
-                    });
+                        sdoWriteRequests.ToList().ForEach(sdoWriteRequest =>
+                        {
+                            EcUtilities.CheckErrorCode(this.Context, EcUtilities.SdoWrite(this.Context, slaveIndex, sdoWriteRequest.Index, sdoWriteRequest.SubIndex, sdoWriteRequest.Dataset), nameof(EcHL.SdoWrite));
+                        });
 
-                    return 0;
-                };
+                        return 0;
+                    };
 
-                EcHL.RegisterCallback(this.Context, currentSlaveIndex, callback);
-                callbacks.Add(callback);
+                    EcHL.RegisterCallback(this.Context, currentSlaveIndex, callback);
+                    _callbacks.Add(callback);
+                }
             }
-
-            callbacks.ForEach(callback =>
-            {
-                GC.KeepAlive(callback);
-            });
         }
 
         private void ConfigureIoMap(IList<SlaveInfo> slaves)
@@ -740,6 +739,8 @@ namespace EtherCAT.NET
             {
                 if (_ioMapPtr != IntPtr.Zero)
                     Marshal.FreeHGlobal(_ioMapPtr);
+
+                _callbacks?.Clear();
 
                 _cts?.Cancel();
 

--- a/src/EtherCAT.NET/Infrastructure/DigitalOut.cs
+++ b/src/EtherCAT.NET/Infrastructure/DigitalOut.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace EtherCAT.NET.Infrastructure
 {
@@ -16,6 +17,41 @@ namespace EtherCAT.NET.Infrastructure
         {
             //
         }
+        
+        /// <summary>
+        /// Gets the Index of Matching Slave Variable Channel.
+        /// </summary>
+        /// <param name="channel"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private (int bitOffset, IntPtr memptr) GetChannelInfo(int channel)
+        {
+            // Calculate total number of variables
+            int totalVariables = _slavePdos.Sum(pdo => pdo.Variables.Count);
+            if (channel < 1 || channel > totalVariables)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channel), "Channel is out of range.");
+            }
+
+            int remainingChannels = channel - 1;
+            int pdoIndex = 0;
+
+            // Find the appropriate PDO and variable index
+            while (remainingChannels >= _slavePdos[pdoIndex].Variables.Count)
+            {
+                remainingChannels -= _slavePdos[pdoIndex].Variables.Count;
+                pdoIndex++;
+            }
+
+            int variableIndex = remainingChannels;
+
+            var pdo = _slavePdos[pdoIndex];
+            var variable = pdo.Variables[variableIndex];
+            var bitOffset = variable.BitOffset;
+            var memptr = new IntPtr((void*)variable.DataPtr);
+            
+            return (bitOffset, memptr);
+        }
 
         /// <summary>
         /// Sets digital output value for a specific channel. 
@@ -25,25 +61,19 @@ namespace EtherCAT.NET.Infrastructure
         /// <returns></returns>
         public bool SetChannel(int channel, bool value)
         {
-            var validChannel = ValidateChannel(channel);
+            var (bitOffset, memptr) = GetChannelInfo(channel);
 
-            if (validChannel)
-            {
-                // get slave variable in order to set bit offset
-                var slaveVariable = _slavePdos[channel - 1].Variables.First();
-                var bitOffset = slaveVariable.BitOffset;
-                var memptr = (int*)slaveVariable.DataPtr;
+            int* memptrInt = (int*)memptr.ToPointer();
 
-                if (value)
-                    // set channel bit
-                    memptr[0] |= 1 << bitOffset;
+            
+            if (value)
+                // set channel bit
+                memptrInt[0] |= 1 << bitOffset;
+            else
+                // clear channel bit
+                memptrInt[0] &= ~(1 << bitOffset);
 
-                else
-                    // clear channel bit
-                    memptr[0] &= ~(1 << bitOffset);  
-            }
-
-            return validChannel;
+            return true;
         }
 
         /// <summary>
@@ -53,18 +83,14 @@ namespace EtherCAT.NET.Infrastructure
         /// <returns></returns>
         public bool ToggleChannel(int channel)
         {
-            var validChannel = ValidateChannel(channel);
+            var (bitOffset, memptr) = GetChannelInfo(channel);
 
-            if (validChannel)
-            {
-                // get slave variable in order to set bit offset
-                var slaveVariable = _slavePdos[channel - 1].Variables.First();
-                var memptr = (int*)slaveVariable.DataPtr;
+            int* memptrInt = (int*)memptr.ToPointer();
 
-                memptr[0] ^= 1 << slaveVariable.BitOffset;
-            }
+            // Toggle channel bit
+            memptrInt[0] ^= 1 << bitOffset;
 
-            return validChannel;
+            return true;
         }
     }
 }

--- a/src/EtherCAT.NET/Infrastructure/SlaveInfo.cs
+++ b/src/EtherCAT.NET/Infrastructure/SlaveInfo.cs
@@ -58,6 +58,8 @@ namespace EtherCAT.NET.Infrastructure
 
         public SlaveInfoDynamicData DynamicData { get; set; }
 
+        public bool IgnoreSMConfig { get; set; } = false;
+
         #endregion
 
         #region "Methods"
@@ -103,8 +105,9 @@ namespace EtherCAT.NET.Infrastructure
         public IEnumerable<SdoWriteRequest> GetConfiguration(IEnumerable<SlaveExtension> slaveExtensions)
         {
             _slaveExtensions = slaveExtensions.ToList();
+            IEnumerable<SdoWriteRequest> configuration = this.GetSdoConfiguration().Concat(this.GetPdoConfiguration());
 
-            return this.GetSdoConfiguration().Concat(this.GetPdoConfiguration()).Concat(this.GetSmConfiguration());
+            return IgnoreSMConfig ? configuration : configuration.Concat(this.GetSmConfiguration());
         }
 
         private IEnumerable<SdoWriteRequest> GetSdoConfiguration()

--- a/src/SOEM.PInvoke/SOEM.PInvoke.csproj
+++ b/src/SOEM.PInvoke/SOEM.PInvoke.csproj
@@ -8,9 +8,22 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <IsWindows>False</IsWindows>
+    <IsLinux>False</IsLinux>
+    <IsLinuxArm>False</IsLinuxArm>
+    <IsPublicBuild>False</IsPublicBuild>
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'True'">True</IsWindows>
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'True'">True</IsLinux>
+    <ProcessArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</ProcessArchitecture>
+    <IsLinuxArm Condition="'$(IsLinux)' == 'True' And ('$(ProcessArchitecture)' == 'Arm' Or '$(ProcessArchitecture)' == 'Arm64')">True</IsLinuxArm>
   </PropertyGroup>
+
+  <Target Name="DumpArchInfo" BeforeTargets="Build">
+    <Message Text="  IsWindows   = '$(IsWindows)'" Importance="High" />
+    <Message Text="  IsLinux     = '$(IsLinux)'" Importance="High" />
+    <Message Text="  IsLinuxArm  = '$(IsLinuxArm)'"  Importance="High" />
+    <Message Text="  ProcessArch = '$(ProcessArchitecture)'" Importance="High" />
+  </Target>
 
   <ItemGroup Condition="'$(IsPublicBuild)' == 'True'">
     <Content Include="./../../artifacts/bin32/SOEM_wrapper/Release/soem_wrapper.dll" Link="runtimes/win-x86/native/soem_wrapper.dll">
@@ -31,7 +44,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsPublicBuild)' == '' AND $(IsWindows) == 'True'">
+  <ItemGroup Condition="'$(IsPublicBuild)' == 'False' AND $(IsWindows) == 'True'">
     <Content Include="./../../artifacts/bin32/SOEM_wrapper/Release/soem_wrapper.dll" Link="runtimes/win-x86/native/soem_wrapper.dll">
       <PackagePath>runtimes/win-x86/native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -42,13 +55,24 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsPublicBuild)' == '' AND $(IsLinux) == 'True'">
+  <ItemGroup Condition="'$(IsPublicBuild)' == 'False' AND $(IsLinux) == 'True' AND '$(IsLinuxArm)' != 'True'">
     <Content Include="./../../artifacts/bin32/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/linux-x86/native/libsoem_wrapper.so">
       <PackagePath>runtimes/linux-x86/native</PackagePath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="./../../artifacts/bin64/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/linux-x64/native/libsoem_wrapper.so">
       <PackagePath>runtimes/linux-x64/native</PackagePath>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsPublicBuild)' == 'False' AND $(IsLinux) == 'True' AND '$(IsLinuxArm)' == 'True'">
+    <Content Include="./../../artifacts/arm32/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/arm/native/libsoem_wrapper.so">
+      <PackagePath>runtimes/arm/native</PackagePath>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="./../../artifacts/arm64/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/arm64/native/libsoem_wrapper.so">
+      <PackagePath>runtimes/arm64/native</PackagePath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
This merge request provides fixes for the following issues:

- Fix serial RX communication issue and improve buffer handling, tested with Beckhoff EL6021
- Fix multiple crashes occurring within the EcHL.PO2SOCallback
- Add IgnoreSMConfig property to optionally bypass the Sync Manager configuration for some slaves (The Bechhoff EL6601 does not support any cyclic SyncManager channels and uses only SM0/SM1 for mailbox data. Its SyncManager configuration is fixed and cannot be modified via SDO writes)

Additionally, init_solution.ps1 and SOEM.PInvoke.csproj have been updated to enable native builds on ARM architectures.
