### PR TITLE
Functions to simplify external handling of K-Bus slaves, plus bug fixes and enhancements

### DIFF
--- a/init_solution.ps1
+++ b/init_solution.ps1
@@ -67,6 +67,7 @@ if ($mWindows)
 {
 	cmake ./../../native `
         -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" `
+        -DCMAKE_POLICY_VERSION_MINIMUM='3.5' `
         -G "Visual Studio 16 2019" `
         -A "Win32"
 }
@@ -81,6 +82,7 @@ elseif ($mLinux)
             -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc `
             -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ `
             -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_POLICY_VERSION_MINIMUM='3.5' `
             -DCMAKE_C_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow' `
             -DCMAKE_CXX_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow'
     }
@@ -88,6 +90,7 @@ elseif ($mLinux)
     {
         cmake ./../../native `
             -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_POLICY_VERSION_MINIMUM='3.5' `
             -DCMAKE_C_FLAGS=-m32 `
             -DCMAKE_CXX_FLAGS=-m32 `
             -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
@@ -121,6 +124,7 @@ if ($mWindows)
 {
 	cmake ./../../native `
         -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" `
+        -DCMAKE_POLICY_VERSION_MINIMUM='3.5' `
         -G "Visual Studio 16 2019" `
         -A "x64"
 }
@@ -130,6 +134,7 @@ elseif ($mLinux)
     {
         cmake ./../../native `
             -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_POLICY_VERSION_MINIMUM='3.5' `
             -DCMAKE_C_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow' `
             -DCMAKE_CXX_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow'
     }
@@ -137,6 +142,7 @@ elseif ($mLinux)
     {
         cmake ./../../native `
             -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_POLICY_VERSION_MINIMUM='3.5' `
             -DCMAKE_C_FLAGS=-m64 `
             -DCMAKE_CXX_FLAGS=-m64
     }
@@ -145,6 +151,7 @@ elseif ($mMacOS)
 {
     cmake ./../../native `
         -DCMAKE_BUILD_TYPE=Release `
+        -DCMAKE_POLICY_VERSION_MINIMUM='3.5' `
         -DCMAKE_C_FLAGS=-m64 `
         -DCMAKE_CXX_FLAGS=-m64
 }

--- a/init_solution.ps1
+++ b/init_solution.ps1
@@ -1,45 +1,154 @@
 Write-Host "Updating Git submodule."
 git submodule update --init --recursive --quiet
 
-# x86
-Write-Host "Creating native x86 project."
-$path = "$($PSScriptRoot)/artifacts/bin32"
-New-Item -Force -ItemType directory -Path $path
+# load .NET types
+$RType = [type]::GetType('System.Runtime.InteropServices.RuntimeInformation, System.Runtime.InteropServices.RuntimeInformation')
+$PType = [type]::GetType('System.Runtime.InteropServices.OSPlatform, System.Runtime.InteropServices.RuntimeInformation')
+
+try
+{
+    if (-not $RType -or -not $PType) { throw }
+
+    $R = $RType
+    $P = $PType
+
+    $mWindows = $R::IsOSPlatform($P::Windows)
+    $mLinux   = $R::IsOSPlatform($P::Linux)
+    $mMacOS   = $R::IsOSPlatform($P::OSX)
+}
+catch
+{
+    # fallback for Windows PowerShell 5.1 oder missing types
+    $mWindows = $env:OS -eq 'Windows_NT'
+    $mLinux   = $false
+    $mMacOS   = $false
+}
+
+Write-Host "Windows: $mWindows, Linux: $mLinux, macOS: $mMacOS"
+
+# detect architecture once
+# try .NET Core API first (PowerShell Core on Linux/macOS)
+$type = [type]::GetType('System.Runtime.InteropServices.RuntimeInformation, System.Runtime.InteropServices.RuntimeInformation')
+
+if ($type)
+{
+    # RuntimeInformation exists
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+}
+else
+{
+    # Fallback for Windows PowerShell / older .NET
+    switch ($env:PROCESSOR_ARCHITECTURE) {
+        'AMD64' { $arch = 'X64'    }
+        'x86'   { $arch = 'X86'    }
+        'ARM64' { $arch = 'Arm64'  }
+        'ARM'   { $arch = 'Arm'    }
+        default { $arch = $env:PROCESSOR_ARCHITECTURE }
+    }
+}
+
+Write-Host "Detected architecture: $arch"
+
+# x86 / arm
+if ($arch -like 'Arm*')
+{
+    Write-Host "Creating native arm project."
+    $path = "$($PSScriptRoot)/artifacts/arm32"
+} else
+{
+    Write-Host "Creating native x86 project."
+    $path = "$($PSScriptRoot)/artifacts/bin32"
+}
+
+New-Item -Force -ItemType Directory -Path $path | Out-Null
 Set-Location -Path $path
 
-if ($IsWindows)
+if ($mWindows)
 {
-	cmake ./../../native -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" -G "Visual Studio 16 2019" -A "Win32"
+	cmake ./../../native `
+        -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" `
+        -G "Visual Studio 16 2019" `
+        -A "Win32"
 }
-elseif ($IsLinux)
+elseif ($mLinux)
 {
-    cmake ./../../native -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m32 -DCMAKE_CXX_FLAGS=-m32 -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
+    if ($arch -like 'Arm*')
+    {
+        # For 32-bit ARM, install the following compilers:
+        # sudo apt-get install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf
+
+        cmake ./../../native `
+            -DCMAKE_C_COMPILER=arm-linux-gnueabihf-gcc `
+            -DCMAKE_CXX_COMPILER=arm-linux-gnueabihf-g++ `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow' `
+            -DCMAKE_CXX_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow'
+    }
+    else
+    {
+        cmake ./../../native `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS=-m32 `
+            -DCMAKE_CXX_FLAGS=-m32 `
+            -DCMAKE_TRY_COMPILE_TARGET_TYPE=STATIC_LIBRARY
+    }
 }
-elseif ($IsMacOS)
+elseif ($mMacOS)
 {
     # The i386 architecture is deprecated for macOS
     throw [System.PlatformNotSupportedException]
 }
-else 
+else
 {
     throw [System.PlatformNotSupportedException]
 }
 
-# x64
-Write-Host "Creating native x64 project."
-$path = "$($PSScriptRoot)/artifacts/bin64"
+# x64 / arm4
+if ($arch -like 'Arm*')
+{
+    Write-Host "Creating native arm64 project."
+    $path = "$($PSScriptRoot)/artifacts/arm64"
+} else
+{
+    Write-Host "Creating native x64 project."
+    $path = "$($PSScriptRoot)/artifacts/bin64"
+}
+
 New-Item -Force -ItemType directory -Path $path
 Set-Location -Path $path
 
-if ($IsWindows)
+if ($mWindows)
 {
-	cmake ./../../native -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" -G "Visual Studio 16 2019" -A "x64"
+	cmake ./../../native `
+        -DCMAKE_CONFIGURATION_TYPES:STRING="Debug;Release" `
+        -G "Visual Studio 16 2019" `
+        -A "x64"
 }
-elseif ($IsLinux -or $IsMacOS)
+elseif ($mLinux)
 {
-    cmake ./../../native -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS=-m64 -DCMAKE_CXX_FLAGS=-m64
+    if ($arch -like 'Arm*')
+    {
+        cmake ./../../native `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow' `
+            -DCMAKE_CXX_FLAGS='-Wno-error=stringop-overflow -Wno-stringop-overflow'
+    }
+    else
+    {
+        cmake ./../../native `
+            -DCMAKE_BUILD_TYPE=Release `
+            -DCMAKE_C_FLAGS=-m64 `
+            -DCMAKE_CXX_FLAGS=-m64
+    }
 }
-else 
+elseif ($mMacOS)
+{
+    cmake ./../../native `
+        -DCMAKE_BUILD_TYPE=Release `
+        -DCMAKE_C_FLAGS=-m64 `
+        -DCMAKE_CXX_FLAGS=-m64
+}
+else
 {
     throw [System.PlatformNotSupportedException]
 }

--- a/native/SOEM_wrapper/exports.def
+++ b/native/SOEM_wrapper/exports.def
@@ -35,6 +35,7 @@ EXPORTS
     RegisterSerialRxCallback
     SetTxBuffer
     UpdateSerialIo
+    UpdateSerialIoStandard
     GetProcessIo
     RequestCommonState
     EnablePreopAckCheck

--- a/native/SOEM_wrapper/exports.def
+++ b/native/SOEM_wrapper/exports.def
@@ -34,7 +34,9 @@ EXPORTS
     RegisterSerialRxCallback
     SetTxBuffer
     UpdateSerialIo
+    GetProcessIo
     RequestCommonState
+    EnablePreopAckCheck
     ScanDevices
     SdoWrite
     UpdateCsa

--- a/native/SOEM_wrapper/exports.def
+++ b/native/SOEM_wrapper/exports.def
@@ -1,4 +1,5 @@
-EXPORTS 
+EXPORTS
+    ALStatusForEachSlave
     CalculateCrc
     CheckSafeOpState
     CompensateDcDrift

--- a/native/SOEM_wrapper/exports.def
+++ b/native/SOEM_wrapper/exports.def
@@ -37,6 +37,7 @@ EXPORTS
     GetProcessIo
     RequestCommonState
     EnablePreopAckCheck
+    RestoreProcessDataWatchdog
     ScanDevices
     SdoWrite
     UpdateCsa

--- a/native/SOEM_wrapper/exports.def
+++ b/native/SOEM_wrapper/exports.def
@@ -41,6 +41,7 @@ EXPORTS
     RestoreProcessDataWatchdog
     ScanDevices
     SdoWrite
+    SdoEntryExists
     UpdateCsa
     UpdateIo
     UploadPdoConfig

--- a/native/SOEM_wrapper/serial.c
+++ b/native/SOEM_wrapper/serial.c
@@ -1,6 +1,6 @@
-/** \file
- * \brief
- * Implementation of serial communication for Beckhoff EL6021.
+/**
+ * @file
+ * @brief Serial handshake for Beckhoff EL/KL EtherCAT terminals;
  */
 
 #include "serial.h"
@@ -10,7 +10,7 @@
 
 #ifndef PACKED
 
-#if defined(__GNUC__) || defined(__ARMEL__) || defined(__APPLE__) 
+#if defined(__GNUC__) || defined(__ARMEL__) || defined(__APPLE__)
 #define PACKED_BEGIN
 #define PACKED   __attribute__((__packed__))
 #define PACKED_END
@@ -22,8 +22,59 @@
 
 #endif
 
+// cast - helper
+#define TX_S(s) ((tx_control_s_t*)((s)->tx_control))
+#define TX_B(s) ((tx_control_b_t*)((s)->tx_control))
 
-// Tx control bitmap
+// makro to set a named field:
+#define TX_SET(s, field, value) do {                    \
+    if ((s)->layout_kind == SMALL)                      \
+        TX_S(s)->field = (value);                       \
+    else                                                \
+        TX_B(s)->field = (value);                       \
+} while(0)
+
+// makro to read a named field (returns uint8_t):
+#define TX_GET_U8(s, field) (uint8_t)(                  \
+    ((s)->layout_kind == SMALL) ?                       \
+        (TX_S(s)->field) : (TX_B(s)->field) )
+
+// cast - helper
+#define RX_S(s) ((rx_status_s_t*)((s)->rx_status))
+#define RX_B(s) ((rx_status_b_t*)((s)->rx_status))
+
+// makro to set a named field:
+#define RX_SET(s, field, value) do {                    \
+    if ((s)->layout_kind == SMALL)                      \
+        RX_S(s)->field = (value);                       \
+    else                                                \
+        RX_B(s)->field = (value);                       \
+} while(0)
+
+// makro to read a named field (returns uint8_t):
+#define RX_GET_U8(s, field) (uint8_t)(                  \
+    ((s)->layout_kind == SMALL) ?                       \
+        (RX_S(s)->field) : (RX_B(s)->field) )
+
+
+// Layout kind of tx control and rx status
+typedef enum { SMALL, BIG } layout_kind_t;
+
+// Tx control bitmap (small layout)
+PACKED_BEGIN
+typedef struct PACKED
+{
+    uint8_t transmit_request : 1;
+    uint8_t receive_accepted : 1;
+    uint8_t init_request : 1;
+    uint8_t send_continuous : 1;
+    uint8_t output_length : 3;
+    uint8_t register_modus : 1;
+
+} tx_control_s_t;
+PACKED_END
+
+// Tx control bitmap (big layout)
 PACKED_BEGIN
 typedef struct PACKED
 {
@@ -37,10 +88,24 @@ typedef struct PACKED
     uint8_t unused_bit_7 : 1;
     uint8_t output_length;
 
-} tx_control_t;
+} tx_control_b_t;
 PACKED_END
 
-// Rx status bitmap
+// Rx status bitmap (small layout)
+PACKED_BEGIN
+typedef struct PACKED
+{
+    uint8_t transmit_accepted : 1;
+    uint8_t receive_request : 1;
+    uint8_t init_accepted : 1;
+    uint8_t buffer_full : 1;
+    uint8_t input_length : 3;
+    uint8_t register_modus : 1;
+
+} rx_status_s_t;
+PACKED_END
+
+// Rx status bitmap (big layout)
 PACKED_BEGIN
 typedef struct PACKED
 {
@@ -54,7 +119,7 @@ typedef struct PACKED
     uint8_t unused_bit_7 : 1;
     uint8_t input_length;
 
-} rx_status_t;
+} rx_status_b_t;
 PACKED_END
 
 
@@ -74,7 +139,8 @@ struct sm_state_data_t
     uint16_t slave;
     bool slave_set;
 
-    tx_control_t* tx_control;
+    layout_kind_t layout_kind;
+    void* tx_control;
     uint8_t* tx_buffer;
     uint8_t* tx_cache;
 
@@ -83,7 +149,7 @@ struct sm_state_data_t
     bool tx_cache_full;
     bool tx_cache_empty;
 
-    rx_status_t* rx_status;
+    void* rx_status;
     uint8_t* rx_buffer;
     uint8_t* rx_cache;
     int rx_offset;
@@ -100,8 +166,25 @@ struct sm_state_data_t
     bool receive_request;
     bool transmit_request;
 
-    void (*rx_callback)(uint16_t slave, uint8_t* buffer, int datasize);
+    rx_callback_t rx_callback;
 };
+
+// Functions to get sizes of tx control and rx status layout
+size_t get_tx_control_size(struct sm_state_data_t* data)
+{
+    if (data->layout_kind == SMALL)
+        return sizeof(tx_control_s_t);
+    else
+        return sizeof(tx_control_b_t);
+}
+
+size_t get_rx_status_size(struct sm_state_data_t* data)
+{
+    if (data->layout_kind == SMALL)
+        return sizeof(rx_status_s_t);
+    else
+        return sizeof(rx_status_b_t);
+}
 
 // State functions
 static void state_init_enter(struct sm_state_data_t* data);
@@ -132,14 +215,14 @@ static bool is_tx_cache_empty(struct sm_state_data_t* data);
  *  returns: Pointer to sm_state_data_t struct.
  */
 static struct sm_state_data_t* set_state(int slave)
-{ 
+{
     struct sm_state_data_t* state = NULL;
     for(int i = 0; i < MAX_SLAVES; i ++)
     {
         if(!_state_data[i].slave_set)
-        {  
+        {
             _state_data[i].slave = slave;
-            _state_data[i].slave_set = true; 
+            _state_data[i].slave_set = true;
             state = &_state_data[i];
             _mapping_index[i] = slave;
             break;
@@ -174,9 +257,12 @@ static struct sm_state_data_t* get_state(int slave)
  *  Initialize state struct data entry.
  *
  *  state: Pointer to sm_state_data_t struct.
+ *  multibyte_ctrl_status: True if both tx control and rx status registers are multi-byte.
+ *
  */
-static void init_state_data(struct sm_state_data_t* state)
+static void init_state_data(struct sm_state_data_t* state, bool multibyte_ctrl_status)
 {
+	state->layout_kind = multibyte_ctrl_status ? BIG : SMALL;
     state->tx_control = NULL;
     state->tx_buffer = NULL;
     state->tx_cache_head = 0;
@@ -200,22 +286,23 @@ static void init_state_data(struct sm_state_data_t* state)
  *  Initialize state struct data entry and alloc buffer for tx/rx cache.
  *
  *  slave: Slave number.
+ *  multibyte_ctrl_status: True if both tx control and rx status registers are multi-byte.
  *  returns: True if successfully initialized, false otherwise.
  */
-bool init_serial(uint16_t slave)
+bool init_serial(uint16_t slave, bool multibyte_ctrl_status)
 {
     struct sm_state_data_t* state = set_state(slave);
     if(state == NULL)
         return false;
-    
-    init_state_data(state);
+
+    init_state_data(state, multibyte_ctrl_status);
     state->current_state = &state_init_enter;
 
     if(state->tx_cache == NULL)
-        state->tx_cache = (uint8_t*)malloc(TX_CACHE_SIZE);
+        state->tx_cache = (uint8_t*)calloc(TX_CACHE_SIZE, sizeof(uint8_t) * TX_CACHE_SIZE);
 
-    if(state->rx_cache == NULL)    
-        state->rx_cache = (uint8_t*)malloc(RX_CACHE_SIZE);
+    if(state->rx_cache == NULL)
+        state->rx_cache = (uint8_t*)calloc(RX_CACHE_SIZE, sizeof(uint8_t) * RX_CACHE_SIZE);
 
     return true;
 }
@@ -234,7 +321,7 @@ bool close_serial(uint16_t slave)
     {
         state->slave_set = false;
         state->slave = 0;
-        init_state_data(state);
+        init_state_data(state, false);
 
         if(state->tx_cache != NULL)
         {
@@ -243,7 +330,7 @@ bool close_serial(uint16_t slave)
         }
 
         if(state->rx_cache != NULL)
-        {    
+        {
             free(state->rx_cache);
             state->rx_cache = NULL;
         }
@@ -269,7 +356,7 @@ bool close_serial(uint16_t slave)
  *  slave: Slave number.
  *  callack: Pointer to callback function.
  */
-void register_rx_callback(uint16_t slave, void callback(uint16_t slave, uint8_t* buffer, int datasize))
+void register_rx_callback(uint16_t slave, rx_callback_t callback)
 {
     struct sm_state_data_t* state = get_state(slave);
     if(state != NULL)
@@ -291,14 +378,14 @@ bool set_tx_buffer(uint16_t slave, uint8_t* tx_buffer, int datasize)
 {
     bool success = false;
     struct sm_state_data_t* data = get_state(slave);
-    
+
     if((data != NULL) && ((TX_CACHE_SIZE - get_nof_tx_cache_elements(data)) >= datasize))
     {
         write_tx_cache(data, tx_buffer, datasize);
         data->transmit_request = true;
         success = true;
     }
-    
+
     return success;
 }
 
@@ -317,9 +404,9 @@ bool get_rx_buffer(uint16_t slave, uint8_t* rx_buffer, int* datasize)
     struct sm_state_data_t* state = get_state(slave);
     if(state != NULL && state->rx_updated)
     {
-        if(*datasize >= state->rx_status->input_length)
+        if(*datasize >= RX_GET_U8(state, input_length))
         {
-            *datasize = state->rx_status->input_length;
+            *datasize = RX_GET_U8(state, input_length);
             memcpy(rx_buffer, state->rx_buffer, *datasize);
             state->rx_updated = false;
             success = true;
@@ -341,11 +428,11 @@ void update_serial(uint16_t slave, uint8_t* tx_data, uint8_t* rx_data)
     struct sm_state_data_t* state = get_state(slave);
     if(state != NULL)
     {
-        state->tx_control = (tx_control_t *)tx_data;
-        state->tx_buffer = tx_data + sizeof(uint16_t);
+        state->tx_control = tx_data;
+        state->tx_buffer = tx_data + get_tx_control_size(state);
 
-        state->rx_status = (rx_status_t *)rx_data;
-        state->rx_buffer = rx_data + sizeof(uint16_t);
+        state->rx_status = rx_data;
+        state->rx_buffer = rx_data + get_rx_status_size(state);
 
         if(state->current_state != NULL)
         {
@@ -365,7 +452,7 @@ static void check_receive_request(struct sm_state_data_t* data)
 {
     if(data->initialized)
     {
-        const uint8_t current_receive_request = data->rx_status->receive_request;
+        const uint8_t current_receive_request = RX_GET_U8(data, receive_request);
 
         if (current_receive_request != data->receive_request_bit)
         {
@@ -384,7 +471,7 @@ static void state_init_enter(struct sm_state_data_t* data)
 {
     if (!data->initialized)
     {
-        data->tx_control->init_request = 1;
+		TX_SET(data, init_request, 1);
         data->next_state = &state_init_run;
     }
     else
@@ -400,13 +487,13 @@ static void state_init_enter(struct sm_state_data_t* data)
  */
 static void state_init_run(struct sm_state_data_t* data)
 {
-    if ((data->tx_control->init_request == 1) && (data->rx_status->init_accepted == 1))
+    if (TX_GET_U8(data, init_request) == 1 && RX_GET_U8(data, init_accepted) == 1)
     {
-        data->tx_control->init_request = 0;
+		TX_SET(data, init_request, 0);
     }
-    else if ((data->tx_control->init_request == 0) && (data->rx_status->init_accepted == 0))
+    else if (TX_GET_U8(data, init_request) == 0 && RX_GET_U8(data, init_accepted) == 0)
     {
-        data->receive_request_bit = data->rx_status->receive_request;
+        data->receive_request_bit = RX_GET_U8(data, receive_request);
         data->initialized = true;
         data->next_state = &state_idle_run;
     }
@@ -441,7 +528,7 @@ static void state_idle_run(struct sm_state_data_t* data)
  */
 static void state_receive_run(struct sm_state_data_t* data)
 {
-    uint8_t length = data->rx_status->input_length;
+    uint8_t length = RX_GET_U8(data, input_length);
     if((data->rx_offset + length) > RX_CACHE_SIZE)
     {
         data->rx_offset = 0;
@@ -453,10 +540,11 @@ static void state_receive_run(struct sm_state_data_t* data)
 
     if(data->rx_callback != NULL)
     {
-        data->rx_callback(data->slave, data->rx_buffer, length);
+        bool rx_fifo_full = RX_GET_U8(data, buffer_full);
+        data->rx_callback(data->slave, data->rx_buffer, length, rx_fifo_full);
     }
-    
-    data->next_state = &state_receive_accepted;
+
+    state_receive_accepted(data);
 }
 
 /*
@@ -469,7 +557,7 @@ static void state_receive_accepted(struct sm_state_data_t* data)
     data->rx_updated = true;
     data->receive_request = false;
     // toggle accepted bit
-    data->tx_control->receive_accepted = !data->tx_control->receive_accepted;
+    TX_SET(data, receive_accepted, !TX_GET_U8(data, receive_accepted));
 
     data->next_state = &state_idle_run;
 }
@@ -491,12 +579,12 @@ static void state_transmit_run(struct sm_state_data_t* data)
 
     // fill tx buffer
     read_tx_cache(data, data->tx_buffer, data_length);
-    data->tx_control->output_length = data_length;
+	TX_SET(data, output_length, data_length);
 
     // store transmit accepted bit
-    data->transmit_accepted_bit = data->rx_status->transmit_accepted;
+    data->transmit_accepted_bit = RX_GET_U8(data, transmit_accepted);
     // toggle transmit request
-    data->tx_control->transmit_request = !data->tx_control->transmit_request;
+    TX_SET(data, transmit_request, !TX_GET_U8(data, transmit_request));
     // set wait for transmit state and wait for tx accepted
     data->next_state = &state_wait_transmit_accepted;
 }
@@ -508,12 +596,12 @@ static void state_transmit_run(struct sm_state_data_t* data)
  */
 static void state_wait_transmit_accepted(struct sm_state_data_t* data)
 {
-    if (data->transmit_accepted_bit != data->rx_status->transmit_accepted)
+    if (data->transmit_accepted_bit != RX_GET_U8(data, transmit_accepted))
     {
         if (get_nof_tx_cache_elements(data) == 0)
         {
             data->transmit_request = false;
-            data->next_state = &state_idle_run;     
+            data->next_state = &state_idle_run;
         }
         else
         {
@@ -589,15 +677,15 @@ static void read_tx_cache(struct sm_state_data_t* data, uint8_t* buffer, int len
 static void update_tx_cache_write(struct sm_state_data_t* data, int length)
 {
     bool overflow = length >= (TX_CACHE_SIZE - get_nof_tx_cache_elements(data));
-	
+
     if(data->tx_cache_full)
         data->tx_cache_tail = (data->tx_cache_tail + length) % TX_CACHE_SIZE;
-    
+
     data->tx_cache_head = (data->tx_cache_head + length) % TX_CACHE_SIZE;
 
     if(overflow)
         data->tx_cache_tail = data->tx_cache_head;
-    
+
     data->tx_cache_full = (data->tx_cache_head == data->tx_cache_tail);
 }
 
@@ -638,7 +726,7 @@ static int get_nof_tx_cache_elements(struct sm_state_data_t* data)
  */
 static bool is_tx_cache_empty(struct sm_state_data_t* data)
 {
-    return (data->tx_cache_tail == data->tx_cache_head) && !data->tx_cache_full; 
+    return (data->tx_cache_tail == data->tx_cache_head) && !data->tx_cache_full;
 }
 
 

--- a/native/SOEM_wrapper/serial.h
+++ b/native/SOEM_wrapper/serial.h
@@ -1,12 +1,14 @@
 #ifndef SERIAL
 #define SERIAL
 
-#include <stdint.h> 
+#include <stdint.h>
 #include <stdbool.h>
 
-bool init_serial(uint16_t slave);
+typedef void (*rx_callback_t)(uint16_t slave, const uint8_t* buffer, int datasize, bool rx_fifo_full);
+
+bool init_serial(uint16_t slave, bool multibyte_ctrl_status);
 bool close_serial(uint16_t slave);
-void register_rx_callback(uint16_t slave, void callback(uint16_t slave, uint8_t* buffer, int datasize));
+void register_rx_callback(uint16_t slave, rx_callback_t callback);
 bool set_tx_buffer(uint16_t slave, uint8_t* tx_buffer, int datasize);
 bool get_rx_buffer(uint16_t slave, uint8_t* rx_buffer, int* datasize);
 void update_serial(uint16_t slave, uint8_t* tx_data, uint8_t* rx_data);

--- a/native/SOEM_wrapper/soem_wrapper.c
+++ b/native/SOEM_wrapper/soem_wrapper.c
@@ -61,7 +61,16 @@ char tmp_char[255];
 
 bool check_ack_preop = true;
 
+// Process data watchdog register
+#define PD_WATCHDOG 0x0420 
 
+// backup for process data watchdog
+typedef struct {
+    uint16_t value;   // saved value
+    uint8_t  saved;   // 1 = value was saved, 0 = no saved value
+} PdWdBackup;
+
+static PdWdBackup pdwd_backup[EC_MAXSLAVE + 1];
 
 
 uint16 CalculateCrc(byte* data)
@@ -1088,9 +1097,44 @@ void CALLCONV EnablePreopAckCheck(bool ack_enabled)
     check_ack_preop = ack_enabled;
 }
 
+static bool read_process_data_watchdog(ecx_contextt* context, uint16 cfgadr, uint16* out)
+{
+    int wkc = ecx_FPRD(context->port, cfgadr, PD_WATCHDOG, sizeof(uint16), out, EC_TIMEOUTRET);
+    return wkc > 0;
+}
+
+static bool write_process_data_watchdog(ecx_contextt* context, uint16 cfgadr, uint16 val)
+{
+    int wkc = ecx_FPWR(context->port, cfgadr, PD_WATCHDOG, sizeof(uint16), &val, EC_TIMEOUTRET);
+    if (wkc <= 0) return false;
+    
+    // read-back
+    uint16 rd = 0;
+    wkc = ecx_FPRD(context->port, cfgadr, PD_WATCHDOG, sizeof(uint16), &rd, EC_TIMEOUTRET);
+    
+    if (wkc <= 0 || rd != val) return false;
+    
+    return true;
+}
+
+int CALLCONV RestoreProcessDataWatchdog(ecx_contextt* context)
+{
+    for (int slaveIndex = 1; slaveIndex < *context->slavecount + 1; slaveIndex++)
+    {
+        PdWdBackup* watchdog_backup = &pdwd_backup[slaveIndex];
+
+        if (watchdog_backup->saved == 0)
+			continue;
+        
+        if (!write_process_data_watchdog(context, context->slavelist[slaveIndex].configadr, watchdog_backup->value))
+            return -0x0105;
+    }
+
+    return 1;
+}
+
 int CALLCONV ScanDevices(ecx_contextt* context, char* interfaceName, ec_slave_info_t** slaveInfoSet, int* slaveCount)
 {
-    int wkc;
     int watchdogTime;
     int slaveIndex;
 
@@ -1145,17 +1189,21 @@ int CALLCONV ScanDevices(ecx_contextt* context, char* interfaceName, ec_slave_in
 
         for (int slaveIndex = 1; slaveIndex < *context->slavecount + 1; slaveIndex++)
         {
-            // clear watchdog trigger enable in SM control register
-            for (int i = 0; i < EC_MAXSM; i++)
-            {
-                if (context->slavelist[slaveIndex].SMtype[i] == 3)
-                    context->slavelist[slaveIndex].SM[i].SMflags &= ~0x40;
-            }
+            uint16 current_watchdog = 0;
 
-            // clear watchdog time process data register
-            if (!(wkc = ecx_FPWR(context->port, context->slavelist[slaveIndex].configadr, 0x420, sizeof(watchdogTime), &watchdogTime, EC_TIMEOUTRET)))
+			// check if watchdog time process data register was already backed up and cleared
+            if (pdwd_backup[slaveIndex].saved == 0)
             {
-                return -0x0102;
+                // read current watchdog time process data register
+                if (read_process_data_watchdog(context, context->slavelist[slaveIndex].configadr, &current_watchdog))
+                {
+                    pdwd_backup[slaveIndex].saved = 1;
+                    pdwd_backup[slaveIndex].value = current_watchdog;
+                }
+
+                // clear watchdog time process data register
+                if (!write_process_data_watchdog(context, context->slavelist[slaveIndex].configadr, 0))
+                    return -0x0102;
             }
 
             // copy relevant data

--- a/native/SOEM_wrapper/soem_wrapper.c
+++ b/native/SOEM_wrapper/soem_wrapper.c
@@ -901,6 +901,21 @@ int CALLCONV RequestCommonState(ecx_contextt* context, uint16 state)
     return context->slavelist[0].state == state ? 1 : -0x0601;
 }
 
+void CALLCONV ALStatusForEachSlave(ecx_contextt* context, void CALLCONV callback(int slave, uint16_t state, uint16_t al, const char* name))
+{
+    if (context == NULL || context->slavecount == NULL || callback == NULL) return;
+
+    (void)ecx_readstate(context);
+    int n = *context->slavecount;
+
+    for (int i = 1; i <= n; ++i)
+    {
+        callback(i, context->slavelist[i].state, 
+            context->slavelist[i].ALstatuscode, 
+            context->slavelist[i].name);
+    }
+}
+
 int CALLCONV CheckSafeOpState(ecx_contextt* context)
 {
     ecx_statecheck(context, 0, EC_STATE_SAFE_OP, EC_TIMEOUTSTATE);
@@ -988,7 +1003,7 @@ int CALLCONV ConfigureDc(ecx_contextt* context, uint32 frameCount, uint32 target
     }
 }
 
-int CALLCONV ConfigureIoMap(ecx_contextt* context, char* ioMap, int* slaveRxPdoOffsetSet, int* slaveTxPdoOffsetSet, int* expectedWorkingCounter)
+int CALLCONV ConfigureIoMap(ecx_contextt* context, uint8* ioMap, int* slaveRxPdoOffsetSet, int* slaveTxPdoOffsetSet, int* expectedWorkingCounter)
 {
     int ioMapSize;
 
@@ -1002,12 +1017,12 @@ int CALLCONV ConfigureIoMap(ecx_contextt* context, char* ioMap, int* slaveRxPdoO
     for (int slave = 1; slave < *context->slavecount + 1; slave++)
     {
         if (context->slavelist[slave].outputs != NULL)
-            slaveRxPdoOffsetSet[slave] = (int)(context->slavelist[slave].outputs - (uint8*)ioMap);
+            slaveRxPdoOffsetSet[slave] = (int)(context->slavelist[slave].outputs - ioMap);
         else
             slaveRxPdoOffsetSet[slave] = -1;
 
         if (context->slavelist[slave].inputs != NULL)
-            slaveTxPdoOffsetSet[slave] = (int)(context->slavelist[slave].inputs - (uint8*)ioMap);
+            slaveTxPdoOffsetSet[slave] = (int)(context->slavelist[slave].inputs - ioMap);
         else
             slaveTxPdoOffsetSet[slave] = -1;
     }

--- a/native/SOEM_wrapper/soem_wrapper.c
+++ b/native/SOEM_wrapper/soem_wrapper.c
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  *	Timeout occurs often. Effects are:
  *
  *	- wkc = 0 BUT ecx_SDOread succeeds (!) (see ecx_readPDOassign) -> Slaves do no start and throw ADS error 0x1D or 0x1E because sync manager length is not correctly calculated.
@@ -914,6 +914,77 @@ void CALLCONV ALStatusForEachSlave(ecx_contextt* context, void CALLCONV callback
             context->slavelist[i].ALstatuscode, 
             context->slavelist[i].name);
     }
+}
+
+static bool sdo_entry_exists(ecx_contextt* context, uint16 slaveIndex, uint16 sdoIndex, uint8 sdoSubIndex)
+{
+    uint8 buf[256];
+    memset(buf, 0, sizeof(buf));
+    int size = sizeof(buf);
+
+    int rc = ecx_SDOread(context, slaveIndex, sdoIndex, sdoSubIndex, FALSE, &size, buf, EC_TIMEOUTRXM);
+    
+    if (rc == 1)
+        return true;
+
+    bool sawRelevantError = false;
+    bool exists = false;
+    ec_errort err;
+
+    while (ecx_iserror(context))
+    {
+        memset(&err, 0, sizeof(err));
+        ecx_poperror(context, &err);
+
+        if (err.Etype != EC_ERR_TYPE_SDO_ERROR) continue;
+        if (err.Slave != slaveIndex)            continue;
+        if (err.Index != sdoIndex)              continue;
+
+        sawRelevantError = true;
+
+        //  index does not exist           sub index does not exist  
+        if (err.AbortCode == 0x06020000 || err.AbortCode == 0x06090011)
+			break;
+
+        exists = true;
+        break;
+    }
+
+    if (sawRelevantError)
+        return exists;
+
+    return false;
+}
+
+bool CALLCONV SdoEntryExists(ecx_contextt* context, uint16 slaveIndex, uint16 sdoIndex, uint8 sdoSubIndex)
+{
+    ec_ODlistt odList;
+    memset(&odList, 0, sizeof(odList));
+
+    if (ecx_readODlist(context, slaveIndex, &odList) == 0 || odList.Entries == 0)
+        return sdo_entry_exists(context, slaveIndex, sdoIndex, sdoSubIndex);
+
+    int item = -1;
+    
+    for (int i = 0; i < odList.Entries; ++i) 
+    {
+        if (odList.Index[i] == sdoIndex) 
+        { 
+            item = i; 
+            break; 
+        }
+    }
+
+    if (item < 0)
+        return sdo_entry_exists(context, slaveIndex, sdoIndex, sdoSubIndex);
+
+    if (sdoSubIndex == 0x00)
+        return true;
+
+    if (ecx_readODdescription(context, (uint16)item, &odList) == 0)
+        return sdo_entry_exists(context, slaveIndex, sdoIndex, sdoSubIndex);
+
+    return (sdoSubIndex <= odList.MaxSub[item]);
 }
 
 int CALLCONV CheckSafeOpState(ecx_contextt* context)

--- a/native/SOEM_wrapper/soem_wrapper.c
+++ b/native/SOEM_wrapper/soem_wrapper.c
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
  *	Timeout occurs often. Effects are:
  *
  *	- wkc = 0 BUT ecx_SDOread succeeds (!) (see ecx_readPDOassign) -> Slaves do no start and throw ADS error 0x1D or 0x1E because sync manager length is not correctly calculated.
@@ -8,8 +8,8 @@
  *		- Increase thread priority
  *		- ...
  *
- *	- SdoWrite takes too long (e.g. EL6601). 
- *		-> Solution: increase timeout SdoWrite() 
+ *	- SdoWrite takes too long (e.g. EL6601).
+ *		-> Solution: increase timeout SdoWrite()
  *
  */
 
@@ -62,7 +62,7 @@ char tmp_char[255];
 bool check_ack_preop = true;
 
 // Process data watchdog register
-#define PD_WATCHDOG 0x0420 
+#define PD_WATCHDOG 0x0420
 
 // backup for process data watchdog
 typedef struct {
@@ -380,7 +380,7 @@ int CALLCONV GetSyncManagerType(ecx_contextt* context, uint16 slaveIndex, uint16
 }
 
 /*
- *  Clear FMMU and SM registers of slave in order to 
+ *  Clear FMMU and SM registers of slave in order to
  *  program bootstrap configuration
  *
  *  context: Current context pointer
@@ -392,21 +392,21 @@ static void clear_FMMU_and_SM_registers(ecx_contextt* context, int slave)
     memset(fmmu_zero, 0, sizeof(fmmu_zero));
 
     /* clean FMMU registers */
-    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU0, 
+    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU0,
         sizeof(fmmu_zero), fmmu_zero, EC_TIMEOUTRET3);
-    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU1, 
+    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU1,
         sizeof(fmmu_zero), fmmu_zero, EC_TIMEOUTRET3);
 
     /* clean SM0 and SM1 registers to set new bootstrap values later */
-    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_SM0, 
+    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_SM0,
         sizeof(ec_smt), sm_zero, EC_TIMEOUTRET3);
-    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_SM1, 
+    ecx_FPWR(context->port, context->slavelist[slave].configadr, ECT_REG_SM1,
         sizeof(ec_smt), sm_zero, EC_TIMEOUTRET3);
 }
 
 /*
  *  Set boot mailbox configuration master --> slave
- * 
+ *
  *  slave: Pointer to ec_slavet
  *  startAddress: SM start address
  *  length: SM length
@@ -423,7 +423,7 @@ static void set_rx_boot_mailbox(ec_slavet* slave, uint16 startAddress, uint16 le
 
 /*
  *  Set boot mailbox configuration slave --> master
- * 
+ *
  *  slave: Pointer to ec_slavet
  *  startAddress: SM start address
  *  length: SM length
@@ -448,19 +448,19 @@ static void set_bootstrap(ecx_contextt* context, int slave)
 {
     memset(FMMU, 0, sizeof(ec_fmmut) * 2);
     /* read content of current FMMU registers */
-    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU0, 
+    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU0,
         sizeof(ec_fmmut), &FMMU[0], EC_TIMEOUTRET3);
-    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU1, 
+    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_FMMU1,
         sizeof(ec_fmmut), &FMMU[1], EC_TIMEOUTRET3);
 
     memset(SM, 0, sizeof(ec_smt) * 2);
     /* read content of current SM registers */
-    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_SM0, 
+    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_SM0,
         sizeof(ec_smt), &SM[0], EC_TIMEOUTRET3);
-    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_SM1, 
+    ecx_FPRD(context->port, context->slavelist[slave].configadr, ECT_REG_SM1,
 	    sizeof(ec_smt), &SM[1], EC_TIMEOUTRET3);
 
-    clear_FMMU_and_SM_registers(context, slave);	
+    clear_FMMU_and_SM_registers(context, slave);
 
     /* read BOOT mailbox data, master -> slave */
     uint32 data = ecx_readeeprom(context, slave, ECT_SII_BOOTRXMBX, EC_TIMEOUTEEP);
@@ -471,10 +471,10 @@ static void set_bootstrap(ecx_contextt* context, int slave)
     set_tx_boot_mailbox(&context->slavelist[slave], (uint16)LO_WORD(data), (uint16)HI_WORD(data));
 
     /* program SM0 mailbox in for slave */
-    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM0, 
+    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM0,
         sizeof(ec_smt), &context->slavelist[slave].SM[0], EC_TIMEOUTRET);
     /* program SM1 mailbox out for slave */
-    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM1, 
+    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM1,
         sizeof(ec_smt), &context->slavelist[slave].SM[1], EC_TIMEOUTRET);
 }
 
@@ -494,10 +494,10 @@ static void revert_bootstrap(ecx_contextt* context, int slave)
     set_tx_boot_mailbox(&context->slavelist[slave], SM[1].StartAddr, SM[1].SMlength);
 
     /* restore SM0 mailbox in for slave */
-    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM0, 
+    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM0,
         sizeof(ec_smt), &context->slavelist[slave].SM[0], EC_TIMEOUTRET);
     /* restore SM1 mailbox out for slave */
-    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM1, 
+    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_SM1,
         sizeof(ec_smt), &context->slavelist[slave].SM[1], EC_TIMEOUTRET);
 
     /* copy stored FMMU registers */
@@ -505,10 +505,10 @@ static void revert_bootstrap(ecx_contextt* context, int slave)
     memcpy(&context->slavelist[slave].FMMU[1], &FMMU[1], sizeof(ec_fmmut));
 
     /* restore FMMU0 */
-    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_FMMU0, 
+    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_FMMU0,
         sizeof(ec_fmmut), &context->slavelist[slave].FMMU[0], EC_TIMEOUTRET);
     /* restore FMMU0 */
-    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_FMMU1, 
+    ecx_FPWR (context->port, context->slavelist[slave].configadr, ECT_REG_FMMU1,
         sizeof(ec_fmmut), &context->slavelist[slave].FMMU[1], EC_TIMEOUTRET);
 }
 
@@ -554,9 +554,9 @@ uint16 CALLCONV RequestState(ecx_contextt* context, int slave, uint16 state)
         set_bootstrap(context, slave);
     }
 
-    /* if current state is EC_STATE_BOOT and requested state is EC_STATE_INIT 
+    /* if current state is EC_STATE_BOOT and requested state is EC_STATE_INIT
         we have to restore FMMU and SM registers */
-    if((context->slavelist[slave].state == EC_STATE_BOOT) && 
+    if((context->slavelist[slave].state == EC_STATE_BOOT) &&
         (state == EC_STATE_INIT))
     {
         revert_bootstrap(context, slave);
@@ -564,7 +564,7 @@ uint16 CALLCONV RequestState(ecx_contextt* context, int slave, uint16 state)
 
     context->slavelist[slave].state = state;
     ecx_writestate(context, slave);
-	
+
     uint16 slaveState = EC_STATE_NONE;
     int counter = 10;
 
@@ -596,7 +596,7 @@ uint16 CALLCONV GetState(ecx_contextt* context, int slave)
  *
  *  context: Current context pointer
  *  slave: Slave number
- *  fileName: File name 
+ *  fileName: File name
  *  length: File length
  *
  *  returns: Workcounter from last slave response
@@ -628,7 +628,7 @@ int CALLCONV DownloadFirmware(ecx_contextt* context, int slave, char *fileName, 
  */
 void CALLCONV RegisterFOECallback(ecx_contextt* context, int CALLCONV callback(uint16 slave, int packetnumber, int datasize))
 {
-    context->FOEhook = (int (*)(uint16 slave, int packetnumber, int datasize))callback;	
+    context->FOEhook = (int (*)(uint16 slave, int packetnumber, int datasize))callback;
 }
 
 /*
@@ -637,8 +637,8 @@ void CALLCONV RegisterFOECallback(ecx_contextt* context, int CALLCONV callback(u
  *  interfaceName: Virtual network interface name.
  *  deviceId [out]: Virtual network device Id != -1 if successful.
  *
- *  returns: Actually virtual network device name set by kernel. 
- * 
+ *  returns: Actually virtual network device name set by kernel.
+ *
  */
 char* CALLCONV CreateVirtualNetworkDevice(char *interfaceName, int* deviceId)
 {
@@ -677,7 +677,7 @@ bool CALLCONV ForwardEthernetToSlave(ecx_contextt* context, int slave, int devic
     {
         ec_etherheadert *bp = (ec_etherheadert *)tx_buffer_net;
         uint16 type = (bp->etype << 8 | bp->etype >> 8);
-       
+
         if (type != ETH_P_ECAT)
         {
             wk = ecx_EOEsend(context, slave, 0, size, (void*)tx_buffer_net, 0);
@@ -688,7 +688,7 @@ bool CALLCONV ForwardEthernetToSlave(ecx_contextt* context, int slave, int devic
 }
 
 /*
- *  Read ethernet data from slave via EoE and forward it to the 
+ *  Read ethernet data from slave via EoE and forward it to the
  *  virtual network device.
  *
  *  context: Current context pointer.
@@ -705,7 +705,7 @@ bool CALLCONV ForwardEthernetToTapDevice(ecx_contextt* context, int slave, int d
 
     if (wk > 0)
     {
-        ec_etherheadert *bp = (ec_etherheadert *)rx_buffer_net;        
+        ec_etherheadert *bp = (ec_etherheadert *)rx_buffer_net;
         uint16 type = (bp->etype << 8 | bp->etype >> 8);
 
         if(type != ETH_P_ECAT)
@@ -728,7 +728,7 @@ char* CreateVirtualSerialPort(int* deviceId)
 {
     memset(tmp_char, 0, sizeof(tmp_char));
     *deviceId = create_virtual_serial_port(tmp_char);
-    
+
     return (char*) tmp_char;
 }
 
@@ -780,7 +780,7 @@ bool CALLCONV ReadSerialDataFromSlave(int slave, int deviceId)
 
     if(data_received)
     {
-        size = write_virtual_serial_port(rx_buffer_term, size_of_rx, deviceId);   
+        size = write_virtual_serial_port(rx_buffer_term, size_of_rx, deviceId);
     }
 
     return (size > 0) && data_received ? true : false;
@@ -790,19 +790,20 @@ bool CALLCONV ReadSerialDataFromSlave(int slave, int deviceId)
  *  Initialize serial handshake processing for slave device.
  *
  *  slave: Slave number.
- * 
+ *  multibyte_ctrl_status: True if both tx control and rx status registers are multi-byte.
+ *
  * returns: True if initialization was successful, false otherwise.
  */
-bool CALLCONV InitSerial(int slave)
+bool CALLCONV InitSerial(int slave, bool multibyte_ctrl_status)
 {
-    return init_serial(slave);
+    return init_serial(slave, multibyte_ctrl_status);
 }
 
 /*
  *  Close serial handshake processing for slave device.
  *
  *  slave: Slave number.
- * 
+ *
  * returns: True if close was successful, false otherwise.
  */
 bool CALLCONV CloseSerial(int slave)
@@ -815,11 +816,11 @@ bool CALLCONV CloseSerial(int slave)
  *
  *  slave: Slave number.
  *  callback: Callback.
- * 
+ *
  */
-void CALLCONV RegisterSerialRxCallback(uint16 slave, void CALLCONV callback(uint16 slave, uint8_t* buffer, int datasize))
+void CALLCONV RegisterSerialRxCallback(uint16 slave, rx_callback_t callback)
 {
-    register_rx_callback(slave, (void (*)(uint16_t slave, uint8_t* buffer, int datasize))callback);
+    register_rx_callback(slave, callback);
 }
 
 /*
@@ -828,7 +829,7 @@ void CALLCONV RegisterSerialRxCallback(uint16 slave, void CALLCONV callback(uint
  *  slave: Slave number.
  *  tx_buffer: Tx buffer
  *  datasize: Size of tx buffer.
- * 
+ *
  * returns: True if buffer was set successfully, false otherwise.
  */
 bool CALLCONV SetTxBuffer(uint16 slave, uint8* tx_buffer, int datasize)
@@ -841,12 +842,27 @@ bool CALLCONV SetTxBuffer(uint16 slave, uint8* tx_buffer, int datasize)
  *
  *  context: Current context pointer.
  *  slave: Slave number.
- * 
+ *
  * returns: True if close was successful, false otherwise.
  */
 void CALLCONV UpdateSerialIo(ecx_contextt* context, int slave)
 {
     update_serial(slave, context->slavelist[slave].outputs, context->slavelist[slave].inputs);
+}
+
+/*
+ * Update serial handshake processing for standard slave device.
+ *
+ * context: Current context pointer.
+ * slave : Slave number.
+ * tx_data: Input process buffer.
+ * rx_data: Output process buffer.
+ *
+ * returns : True if close was successful, false otherwise.
+*/
+void CALLCONV UpdateSerialIoStandard(int slave, uint8_t* tx_data, uint8_t* rx_data)
+{
+    update_serial(slave, tx_data, rx_data);
 }
 
 /*
@@ -856,7 +872,7 @@ void CALLCONV UpdateSerialIo(ecx_contextt* context, int slave)
  *  slave: Slave number.
  *  output: Output buffer.
  *  input: Input buffer.
- * 
+ *
  */
 void CALLCONV GetProcessIo(ecx_contextt* context, int slave, char** output, char** input)
 {
@@ -897,7 +913,7 @@ int CALLCONV RequestCommonState(ecx_contextt* context, uint16 state)
 
         ecx_statecheck(context, 0, state, 5 * EC_TIMEOUTSTATE);
     } while (counter-- && (context->slavelist[0].state != state));
-    
+
     return context->slavelist[0].state == state ? 1 : -0x0601;
 }
 
@@ -910,8 +926,8 @@ void CALLCONV ALStatusForEachSlave(ecx_contextt* context, void CALLCONV callback
 
     for (int i = 1; i <= n; ++i)
     {
-        callback(i, context->slavelist[i].state, 
-            context->slavelist[i].ALstatuscode, 
+        callback(i, context->slavelist[i].state,
+            context->slavelist[i].ALstatuscode,
             context->slavelist[i].name);
     }
 }
@@ -923,7 +939,7 @@ static bool sdo_entry_exists(ecx_contextt* context, uint16 slaveIndex, uint16 sd
     int size = sizeof(buf);
 
     int rc = ecx_SDOread(context, slaveIndex, sdoIndex, sdoSubIndex, FALSE, &size, buf, EC_TIMEOUTRXM);
-    
+
     if (rc == 1)
         return true;
 
@@ -942,7 +958,7 @@ static bool sdo_entry_exists(ecx_contextt* context, uint16 slaveIndex, uint16 sd
 
         sawRelevantError = true;
 
-        //  index does not exist           sub index does not exist  
+        //  index does not exist           sub index does not exist
         if (err.AbortCode == 0x06020000 || err.AbortCode == 0x06090011)
 			break;
 
@@ -965,13 +981,13 @@ bool CALLCONV SdoEntryExists(ecx_contextt* context, uint16 slaveIndex, uint16 sd
         return sdo_entry_exists(context, slaveIndex, sdoIndex, sdoSubIndex);
 
     int item = -1;
-    
-    for (int i = 0; i < odList.Entries; ++i) 
+
+    for (int i = 0; i < odList.Entries; ++i)
     {
-        if (odList.Index[i] == sdoIndex) 
-        { 
-            item = i; 
-            break; 
+        if (odList.Index[i] == sdoIndex)
+        {
+            item = i;
+            break;
         }
     }
 
@@ -1126,7 +1142,7 @@ int CALLCONV SdoWrite(ecx_contextt* context, uint16 slaveIndex, uint16 sdoIndex,
         if (sdoSubIndex == 0)
         {
             uint8* datasetPadded = calloc(totalByteCount + 1, 1);
-            
+
             datasetPadded[0] = dataset[0];
 
             for (int i = 1; i < totalByteCount; i++)
@@ -1193,13 +1209,13 @@ static bool write_process_data_watchdog(ecx_contextt* context, uint16 cfgadr, ui
 {
     int wkc = ecx_FPWR(context->port, cfgadr, PD_WATCHDOG, sizeof(uint16), &val, EC_TIMEOUTRET);
     if (wkc <= 0) return false;
-    
+
     // read-back
     uint16 rd = 0;
     wkc = ecx_FPRD(context->port, cfgadr, PD_WATCHDOG, sizeof(uint16), &rd, EC_TIMEOUTRET);
-    
+
     if (wkc <= 0 || rd != val) return false;
-    
+
     return true;
 }
 
@@ -1211,7 +1227,7 @@ int CALLCONV RestoreProcessDataWatchdog(ecx_contextt* context)
 
         if (watchdog_backup->saved == 0)
 			continue;
-        
+
         if (!write_process_data_watchdog(context, context->slavelist[slaveIndex].configadr, watchdog_backup->value))
             return -0x0105;
     }
@@ -1243,7 +1259,7 @@ int CALLCONV ScanDevices(ecx_contextt* context, char* interfaceName, ec_slave_in
         do
         {
             ecx_statecheck(context, 0, EC_STATE_PRE_OP, EC_TIMEOUTSTATE);
-            
+
             for (int slaveIndex = 1; slaveIndex < *context->slavecount + 1; slaveIndex++)
             {
                 if(context->slavelist[slaveIndex].state != PREOP_STATE_CHECK)
@@ -1252,7 +1268,7 @@ int CALLCONV ScanDevices(ecx_contextt* context, char* interfaceName, ec_slave_in
                     ecx_writestate(context, slaveIndex);
                 }
             }
-            
+
         } while (counter-- && (context->slavelist[0].state != PREOP_STATE_CHECK));
 
         if (context->slavelist[0].state != PREOP_STATE_CHECK)
@@ -1390,7 +1406,7 @@ int CALLCONV UpdateIo(ecx_contextt* context, int64* dcTime)
     {
         wkc = ecx_receive_processdata(context, EC_TIMEOUTRET);
     }
-    
+
     *dcTime = *context->DCtime;
 
     return wkc;

--- a/native/SOEM_wrapper/soem_wrapper.c
+++ b/native/SOEM_wrapper/soem_wrapper.c
@@ -59,6 +59,8 @@ uint8 rx_buffer_term[1500];
 
 char tmp_char[255];
 
+bool check_ack_preop = true;
+
 
 
 
@@ -839,6 +841,21 @@ void CALLCONV UpdateSerialIo(ecx_contextt* context, int slave)
 }
 
 /*
+ *  Get process buffers of specific slave device.
+ *
+ *  context: Current context pointer.
+ *  slave: Slave number.
+ *  output: Output buffer.
+ *  input: Input buffer.
+ * 
+ */
+void CALLCONV GetProcessIo(ecx_contextt* context, int slave, char** output, char** input)
+{
+    *output = context->slavelist[slave].outputs;
+    *input = context->slavelist[slave].inputs;
+}
+
+/*
  *  Request specific state for all slaves.
  *
  *  context: Current context pointer
@@ -1066,6 +1083,11 @@ int CALLCONV SdoWrite(ecx_contextt* context, uint16 slaveIndex, uint16 sdoIndex,
     }
 }
 
+void CALLCONV EnablePreopAckCheck(bool ack_enabled)
+{
+    check_ack_preop = ack_enabled;
+}
+
 int CALLCONV ScanDevices(ecx_contextt* context, char* interfaceName, ec_slave_info_t** slaveInfoSet, int* slaveCount)
 {
     int wkc;
@@ -1085,7 +1107,8 @@ int CALLCONV ScanDevices(ecx_contextt* context, char* interfaceName, ec_slave_in
         *slaveCount = *context->slavecount;
 
         // request PREOP state for all slaves
-        int counter = 5;
+        int counter = 15;
+        uint16 PREOP_STATE_CHECK = check_ack_preop ? (EC_STATE_PRE_OP | EC_STATE_ACK) : EC_STATE_PRE_OP;
 
         do
         {
@@ -1093,16 +1116,16 @@ int CALLCONV ScanDevices(ecx_contextt* context, char* interfaceName, ec_slave_in
             
             for (int slaveIndex = 1; slaveIndex < *context->slavecount + 1; slaveIndex++)
             {
-                if(context->slavelist[slaveIndex].state != (EC_STATE_PRE_OP | EC_STATE_ACK))
+                if(context->slavelist[slaveIndex].state != PREOP_STATE_CHECK)
                 {
-                    context->slavelist[slaveIndex].state = EC_STATE_PRE_OP | EC_STATE_ACK;
+                    context->slavelist[slaveIndex].state = PREOP_STATE_CHECK;
                     ecx_writestate(context, slaveIndex);
                 }
             }
             
-        } while (counter-- && (context->slavelist[0].state != (EC_STATE_PRE_OP | EC_STATE_ACK)));
+        } while (counter-- && (context->slavelist[0].state != PREOP_STATE_CHECK));
 
-        if (context->slavelist[0].state != (EC_STATE_PRE_OP | EC_STATE_ACK))
+        if (context->slavelist[0].state != PREOP_STATE_CHECK)
             return -0x0104;
 
         // read real CSA value from EEPROM

--- a/native/SOEM_wrapper/soem_wrapper.h
+++ b/native/SOEM_wrapper/soem_wrapper.h
@@ -2,7 +2,7 @@
 #if defined _WIN32
     #define CALLCONV __stdcall
 // ARM architecture 
-#elif defined __ARMEL__
+#elif defined __ARM_ARCH
     #define CALLCONV
 // GCC
 #elif defined __GNUC__

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -279,6 +279,8 @@ namespace EtherCAT.NET
 
             EcUtilities.CheckErrorCode(this.Context, EcHL.RequestCommonState(this.Context, (UInt16)SlaveState.Operational), nameof(EcHL.RequestCommonState));
 
+            EcUtilities.CheckErrorCode(this.Context, EcHL.RestoreProcessDataWatchdog(this.Context), nameof(EcHL.RestoreProcessDataWatchdog));
+
             #endregion
 
             if (_watchdogTask == null)

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -575,6 +575,16 @@ namespace EtherCAT.NET
             EcHL.UpdateSerialIo(this.Context, slaveIndex);
         }
 
+        /// <summary>
+        /// Returns process data for slave device.
+        /// </summary>
+        /// <param name="slaveIndex">The index of the corresponding slave.</param>
+        /// <param name="output">Output buffer.</param>
+        /// <param name="input">Input buffer.</param>
+        public void GetProcessIo(int slaveIndex, out IntPtr output, out IntPtr input)
+        {
+            EcHL.GetProcessIo(this.Context, slaveIndex, out output, out input);
+        }
 
         /// <summary>
         /// Activate watchdog. 

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -55,8 +55,7 @@ namespace EtherCAT.NET
         private Task _watchdogTask;
         private bool _watchDogActive = true;
 
-        // sdo callbacks
-        List<EcHL.PO2SOCallback> _callbacks = new List<EcHL.PO2SOCallback>();
+        private static readonly Dictionary<ushort, GCHandle> _callbackHandles = [];
 
         #endregion
 
@@ -125,25 +124,48 @@ namespace EtherCAT.NET
             {
                 // SDO / PDO config / PDO assign
                 var currentSlaveIndex = (ushort)(Convert.ToUInt16(slaves.ToList().IndexOf(slave)) + 1);
-                var extensions = slave.Extensions;
+                var sdoWriteRequests = slave.GetConfiguration(slave.Extensions).ToList();
 
-                var sdoWriteRequests = slave.GetConfiguration(extensions).ToList();
-
-                if (sdoWriteRequests.Count != 0)
+                if (_callbackHandles.TryGetValue(currentSlaveIndex, out var oldHandle))
                 {
-                    EcHL.PO2SOCallback callback = slaveIndex =>
-                    {
-                        sdoWriteRequests.ToList().ForEach(sdoWriteRequest =>
-                        {
-                            EcUtilities.CheckErrorCode(this.Context, EcUtilities.SdoWrite(this.Context, slaveIndex, sdoWriteRequest.Index, sdoWriteRequest.SubIndex, sdoWriteRequest.Dataset), nameof(EcHL.SdoWrite));
-                        });
+                    EcHL.RegisterCallback(this.Context, currentSlaveIndex, IntPtr.Zero);
 
-                        return 0;
-                    };
+                    if (oldHandle.IsAllocated)
+                        oldHandle.Free();
 
-                    EcHL.RegisterCallback(this.Context, currentSlaveIndex, callback);
-                    _callbacks.Add(callback);
+                    _callbackHandles.Remove(currentSlaveIndex);
                 }
+
+                if (sdoWriteRequests.Count == 0)
+                {
+                    EcHL.RegisterCallback(this.Context, currentSlaveIndex, IntPtr.Zero);
+                    continue;
+                }
+
+                EcHL.PO2SOCallback callback = slaveIndex =>
+                {
+                    foreach (var sdoWriteRequest in sdoWriteRequests)
+                    {
+
+                        var errorCode = EcUtilities.SdoWrite(this.Context, slaveIndex, sdoWriteRequest.Index,
+                            sdoWriteRequest.SubIndex, sdoWriteRequest.Dataset);
+
+                        if (errorCode <= 0)
+                        {
+                            _logger.LogError("SDO write failed for slave {SlaveIndex} at index 0x{Index:X4}/{SubIndex:X2}",
+                                slaveIndex, sdoWriteRequest.Index, sdoWriteRequest.SubIndex);
+
+                            EcUtilities.LogErrorCode(Context, errorCode, _logger, nameof(ConfigureSlaves));
+                        }
+                    }
+
+                    return 0;
+                };
+
+                var handle = GCHandle.Alloc(callback);
+                _callbackHandles[currentSlaveIndex] = handle;
+
+                EcHL.RegisterCallback(this.Context, currentSlaveIndex, Marshal.GetFunctionPointerForDelegate(callback));
             }
         }
 
@@ -246,7 +268,7 @@ namespace EtherCAT.NET
 
             #region "PreOp"
 
-            var actualSlave = EcUtilities.ScanDevices(this.Context, _settings.InterfaceName, null);
+            var actualSlave = EcUtilities.ScanDevices(this.Context, _settings.InterfaceName, null, _logger);
 
             if (rootSlave == null)
             {
@@ -271,13 +293,23 @@ namespace EtherCAT.NET
 
             #region "SafeOp"
 
-            EcUtilities.CheckErrorCode(this.Context, EcHL.CheckSafeOpState(this.Context), nameof(EcHL.CheckSafeOpState));
+            var safeOpState = EcHL.CheckSafeOpState(this.Context);
+
+            if (safeOpState <= 0)
+                EcUtilities.DumpALStatus(this.Context, _logger);
+
+            EcUtilities.CheckErrorCode(this.Context, safeOpState, nameof(EcHL.CheckSafeOpState));
 
             #endregion
 
             #region "Op"
 
-            EcUtilities.CheckErrorCode(this.Context, EcHL.RequestCommonState(this.Context, (UInt16)SlaveState.Operational), nameof(EcHL.RequestCommonState));
+            var operationalState = EcHL.RequestCommonState(this.Context, (UInt16)SlaveState.Operational);
+
+            if (operationalState <= 0)
+                EcUtilities.DumpALStatus(this.Context, _logger);
+
+            EcUtilities.CheckErrorCode(this.Context, operationalState, nameof(EcHL.RequestCommonState));
 
             EcUtilities.CheckErrorCode(this.Context, EcHL.RestoreProcessDataWatchdog(this.Context), nameof(EcHL.RestoreProcessDataWatchdog));
 
@@ -703,6 +735,9 @@ namespace EtherCAT.NET
 
                         if (_statusCheckFailedCounter >= _settings.MaxRetries)
                         {
+                            _logger.LogInformation("Watchdog is starting reconfiguration lowest slave state is {State}", state);
+                            EcUtilities.DumpALStatus(this.Context, _logger);
+
                             try
                             {
                                 lock (_lock)
@@ -752,9 +787,13 @@ namespace EtherCAT.NET
                 if (_ioMapPtr != IntPtr.Zero)
                     Marshal.FreeHGlobal(_ioMapPtr);
 
-                _callbacks?.Clear();
-
                 _cts?.Cancel();
+
+                foreach (var handle in _callbackHandles.Values)
+                {
+                    if (handle.IsAllocated)
+                        handle.Free();
+                }
 
                 try
                 {

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -55,6 +55,9 @@ namespace EtherCAT.NET
         private Task _watchdogTask;
         private bool _watchDogActive = true;
 
+        // sdo callbacks
+        List<EcHL.PO2SOCallback> _callbacks = new List<EcHL.PO2SOCallback>();
+
         #endregion
 
         #region Constructors
@@ -118,8 +121,6 @@ namespace EtherCAT.NET
 
         private void ConfigureSlaves(IList<SlaveInfo> slaves)
         {
-            var callbacks = new List<EcHL.PO2SOCallback>();
-
             foreach (var slave in slaves)
             {
                 // SDO / PDO config / PDO assign
@@ -128,24 +129,22 @@ namespace EtherCAT.NET
 
                 var sdoWriteRequests = slave.GetConfiguration(extensions).ToList();
 
-                EcHL.PO2SOCallback callback = slaveIndex =>
+                if (sdoWriteRequests.Count != 0)
                 {
-                    sdoWriteRequests.ToList().ForEach(sdoWriteRequest =>
+                    EcHL.PO2SOCallback callback = slaveIndex =>
                     {
-                        EcUtilities.CheckErrorCode(this.Context, EcUtilities.SdoWrite(this.Context, slaveIndex, sdoWriteRequest.Index, sdoWriteRequest.SubIndex, sdoWriteRequest.Dataset), nameof(EcHL.SdoWrite));
-                    });
+                        sdoWriteRequests.ToList().ForEach(sdoWriteRequest =>
+                        {
+                            EcUtilities.CheckErrorCode(this.Context, EcUtilities.SdoWrite(this.Context, slaveIndex, sdoWriteRequest.Index, sdoWriteRequest.SubIndex, sdoWriteRequest.Dataset), nameof(EcHL.SdoWrite));
+                        });
 
-                    return 0;
-                };
+                        return 0;
+                    };
 
-                EcHL.RegisterCallback(this.Context, currentSlaveIndex, callback);
-                callbacks.Add(callback);
+                    EcHL.RegisterCallback(this.Context, currentSlaveIndex, callback);
+                    _callbacks.Add(callback);
+                }
             }
-
-            callbacks.ForEach(callback =>
-            {
-                GC.KeepAlive(callback);
-            });
         }
 
         private void ConfigureIoMap(IList<SlaveInfo> slaves)
@@ -740,6 +739,8 @@ namespace EtherCAT.NET
             {
                 if (_ioMapPtr != IntPtr.Zero)
                     Marshal.FreeHGlobal(_ioMapPtr);
+
+                _callbacks?.Clear();
 
                 _cts?.Cancel();
 

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -5,7 +5,6 @@ using Microsoft.Extensions.Logging.Abstractions;
 using SOEM.PInvoke;
 using System;
 using System.Collections.Generic;
-using System.Data;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -62,7 +61,7 @@ namespace EtherCAT.NET
 
         #region Constructors
 
-        public EcMaster(EcSettings settings) 
+        public EcMaster(EcSettings settings)
             : this(settings, NullLogger.Instance)
         {
             //
@@ -113,7 +112,7 @@ namespace EtherCAT.NET
 
             for (int i = 0; i <= actualSlaves.Count() - 1; i++)
             {
-                if (!(actualSlaves[i].ProductCode == slaves[i].ProductCode 
+                if (!(actualSlaves[i].ProductCode == slaves[i].ProductCode
                    && actualSlaves[i].Revision == slaves[i].Revision))
                     throw new Exception(ErrorMessage.EthercatGateway_EtherCATConfigurationMismatch);
             }
@@ -198,11 +197,11 @@ namespace EtherCAT.NET
                     var slaveByteOffset = slavePdoOffsets[slaves.ToList().IndexOf(slave) + 1];
 
                     // reset bit offset if byte offset changes
-                    if( slaveByteOffset != ioMapByteOffset )
+                    if (slaveByteOffset != ioMapByteOffset)
                         ioMapBitOffset = 0;
 
                     ioMapByteOffset = slaveByteOffset;
-                    
+
                     foreach (var variable in slave.DynamicData.Pdos
                         .Where(pdo => pdo.SyncManager >= 0)
                         .SelectMany(pdo => pdo.Variables)
@@ -345,13 +344,13 @@ namespace EtherCAT.NET
 
                     if (_lostFrameCounter == _settings.CycleFrequency)
                     {
-                        _logger.LogWarning($"frame loss occured ({ _settings.CycleFrequency } frames)");
+                        _logger.LogWarning($"frame loss occured ({_settings.CycleFrequency} frames)");
                         _lostFrameCounter = 0;
                     }
 
                     if (_wkcMismatchCounter == _settings.CycleFrequency)
                     {
-                        _logger.LogWarning($"working counter mismatch { _actualWorkingCounter }/{ _expectedWorkingCounter }");
+                        _logger.LogWarning($"working counter mismatch {_actualWorkingCounter}/{_expectedWorkingCounter}");
                         //Trace.WriteLine(EcUtilities.GetSlaveStateDescription(_ecSettings.RootSlaves.SelectMany(x => x.Descendants()).ToList()));
                         _wkcMismatchCounter = 0;
                     }
@@ -577,10 +576,11 @@ namespace EtherCAT.NET
         /// Initialize serial handshake processing for slave device.
         /// </summary>
         /// <param name="slaveIndex">The index of the corresponding slave.</param>
+        /// <param name="multibyteCtrlStatus">True if both tx control and rx status registers are multi-byte.</param>
         /// <returns>True if initialization was successful, false otherwise.</returns>
-        public bool InitSerial(int slaveIndex)
+        public bool InitSerial(int slaveIndex, bool multibyteCtrlStatus)
         {
-            return EcHL.InitSerial(slaveIndex);
+            return EcHL.InitSerial(slaveIndex, multibyteCtrlStatus);
         }
 
         /// <summary>
@@ -613,6 +613,18 @@ namespace EtherCAT.NET
         {
             if (!_isReconfiguring)
                 EcHL.UpdateSerialIo(this.Context, slaveIndex);
+        }
+
+        /// <summary>
+        /// Update serial handshake processing for standard slave device.
+        /// </summary>
+        /// <param name="slaveIndex">The index of the corresponding slave.</param>
+        /// <param name="input">Input process buffer.</param>
+        /// <param name="output">Output process buffer.</param>
+        public void UpdateSerialIoStandard(int slaveIndex, IntPtr input, IntPtr output)
+        {
+            if (!_isReconfiguring)
+                EcHL.UpdateSerialIoStandard(slaveIndex, input, output);
         }
 
         /// <summary>
@@ -672,7 +684,7 @@ namespace EtherCAT.NET
         /// <param name="fileName">Absolute path to firmware file.</param>
         /// <returns>True if operation was successful, false otherwise./returns>
         public bool DownloadFirmware(int slaveIndex, string fileName)
-        { 
+        {
             FileInfo fileInfo = new FileInfo(fileName);
             if (!fileInfo.Exists)
                 return false;
@@ -690,9 +702,9 @@ namespace EtherCAT.NET
                         int totalPackages = 0;
                         int remainingSize = -1;
 
-                        EcHL.FOECallback callback = (slaveIndex, packageNumber,  datasize) =>
+                        EcHL.FOECallback callback = (slaveIndex, packageNumber, datasize) =>
                         {
-                            if(packageNumber == 0)
+                            if (packageNumber == 0)
                                 _logger.LogInformation($"FoE: Write {datasize} bytes to {slaveIndex}. slave");
                             else
                                 _logger.LogInformation($"FoE: {packageNumber}. package with {remainingSize - datasize} bytes written to {slaveIndex}. slave. Remaining data: {datasize} bytes");
@@ -700,7 +712,7 @@ namespace EtherCAT.NET
                             if (currentPackageNumber != packageNumber)
                             {
                                 currentPackageNumber = packageNumber;
-                                if(packageNumber != 0)
+                                if (packageNumber != 0)
                                     totalPackages++;
                             }
 
@@ -776,10 +788,10 @@ namespace EtherCAT.NET
                         }
 
                         _statusCheckFailedCounter = 0;
-                    }    
+                    }
                 }
                 _cts.Token.WaitHandle.WaitOne(TimeSpan.FromSeconds(_settings.WatchdogSleepTime));
-            }   
+            }
         }
 
         #region IDisposable Support

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -5,13 +5,14 @@ using Microsoft.Extensions.Logging.Abstractions;
 using SOEM.PInvoke;
 using System;
 using System.Collections.Generic;
+using System.Data;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
-using System.IO;
 
 namespace EtherCAT.NET
 {
@@ -146,6 +147,10 @@ namespace EtherCAT.NET
                 {
                     foreach (var sdoWriteRequest in sdoWriteRequests)
                     {
+                        var bytes = sdoWriteRequest.Dataset.SelectMany(value => value.ToByteArray()).ToArray();
+
+                        _logger.LogInformation("SDO write for slave {SlaveIndex} at index 0x{Index:X4}/{SubIndex:X2} data {Data}",
+                            slaveIndex, sdoWriteRequest.Index, sdoWriteRequest.SubIndex, BitConverter.ToString(bytes));
 
                         var errorCode = EcUtilities.SdoWrite(this.Context, slaveIndex, sdoWriteRequest.Index,
                             sdoWriteRequest.SubIndex, sdoWriteRequest.Dataset);
@@ -509,7 +514,7 @@ namespace EtherCAT.NET
         /// <returns>True if operation was successful, false otherwise.</returns>
         public bool ForwardEthernetToSlave(int slaveIndex, int deviceId)
         {
-            return EcHL.ForwardEthernetToSlave(this.Context, slaveIndex, deviceId);
+            return !_isReconfiguring && EcHL.ForwardEthernetToSlave(this.Context, slaveIndex, deviceId);
         }
 
         /// <summary>
@@ -521,7 +526,7 @@ namespace EtherCAT.NET
         /// <returns>True if operation was successful, false otherwise.</returns>
         public bool ForwardEthernetToTapDevice(int slaveIndex, int deviceId)
         {
-            return EcHL.ForwardEthernetToTapDevice(this.Context, slaveIndex, deviceId);
+            return !_isReconfiguring && EcHL.ForwardEthernetToTapDevice(this.Context, slaveIndex, deviceId);
         }
 
         /// <summary>
@@ -554,7 +559,7 @@ namespace EtherCAT.NET
         /// <returns>True if any data was forwarded, false otherwise.</returns>
         public bool SendSerialDataToSlave(int slaveIndex, int deviceId)
         {
-            return EcHL.SendSerialDataToSlave(slaveIndex, deviceId);
+            return !_isReconfiguring && EcHL.SendSerialDataToSlave(slaveIndex, deviceId);
         }
 
         /// <summary>
@@ -565,7 +570,7 @@ namespace EtherCAT.NET
         /// <returns>True if any data was forwarded, false otherwise.</returns>
         public bool ReadSerialDataFromSlave(int slaveIndex, int deviceId)
         {
-            return EcHL.ReadSerialDataFromSlave(slaveIndex, deviceId);
+            return !_isReconfiguring && EcHL.ReadSerialDataFromSlave(slaveIndex, deviceId);
         }
 
         /// <summary>
@@ -606,7 +611,8 @@ namespace EtherCAT.NET
         /// <param name="slaveIndex">The index of the corresponding slave.</param>
         public void UpdateSerialIo(int slaveIndex)
         {
-            EcHL.UpdateSerialIo(this.Context, slaveIndex);
+            if (!_isReconfiguring)
+                EcHL.UpdateSerialIo(this.Context, slaveIndex);
         }
 
         /// <summary>

--- a/src/EtherCAT.NET/EcMaster.cs
+++ b/src/EtherCAT.NET/EcMaster.cs
@@ -55,7 +55,7 @@ namespace EtherCAT.NET
         private Task _watchdogTask;
         private bool _watchDogActive = true;
 
-        private static readonly Dictionary<ushort, GCHandle> _callbackHandles = [];
+        private static readonly Dictionary<ushort, GCHandle> _callbackHandles = new Dictionary<ushort, GCHandle>();
 
         #endregion
 

--- a/src/EtherCAT.NET/EcUtilities.cs
+++ b/src/EtherCAT.NET/EcUtilities.cs
@@ -1,8 +1,10 @@
 ﻿using EtherCAT.NET.Extension;
 using EtherCAT.NET.Infrastructure;
+using Microsoft.Extensions.Logging;
 using SOEM.PInvoke;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net.NetworkInformation;
 using System.Runtime.CompilerServices;
@@ -98,6 +100,63 @@ namespace EtherCAT.NET
             return rawData.ToArray();
         }
 
+        public static string GetErrorString(IntPtr context, int errorCode, [CallerMemberName] string caller = "")
+            => BuildErrorText(context, errorCode, caller);
+
+        public static void LogErrorCode(IntPtr context, int errorCode, ILogger log, [CallerMemberName] string caller = "")
+        {
+            var text = BuildErrorText(context, errorCode, caller);
+
+            if (string.IsNullOrEmpty(text))
+                return;
+
+            using var sr = new StringReader(text);
+            string line;
+
+            while ((line = sr.ReadLine()) != null)
+            {
+                if (!string.IsNullOrWhiteSpace(line))
+                    log.LogError("{Line}", line);
+            }
+        }
+
+        /// <summary>
+        /// Checks if unmanaged status code represents an error. If true this error will be returned.
+        /// </summary>
+        /// <param name="errorCode">The error code.</param>
+        /// <param name="callerMemberName">The name of the calling function.</param>
+        /// <returns>Returns error string.</returns>
+        private static string BuildErrorText(IntPtr context, int errorCode, string caller)
+        {
+            if (errorCode > 0)
+                return string.Empty;
+
+            errorCode = -errorCode;
+
+            var messageManaged = ErrorMessage.ResourceManager.GetString($"Native_0x{errorCode:X4}");
+
+            if (string.IsNullOrWhiteSpace(messageManaged))
+                messageManaged = ErrorMessage.Native_0xFFFF;
+
+            var sb = new StringBuilder().Append(caller).Append(" failed (0x").Append(errorCode.ToString("X4")).Append("): ").Append(messageManaged);
+            var ethercatHeader = false;
+
+            while (EcHL.HasEcError(context))
+            {
+                var messageSoem = Marshal.PtrToStringAnsi(EcHL.GetNextError(context));
+
+                if (!ethercatHeader)
+                {
+                    ethercatHeader = true;
+                    sb.AppendLine().AppendLine("EtherCAT message:");
+                }
+
+                sb.Append(messageSoem);
+            }
+
+            return sb.ToString();
+        }
+
         /// <summary>
         /// Checks if unmanaged status code represents an error. If true this error will be thrown.
         /// </summary>
@@ -105,35 +164,10 @@ namespace EtherCAT.NET
         /// <param name="callerMemberName">The name of the calling function.</param>
         public static void CheckErrorCode(IntPtr context, int errorCode, [CallerMemberName()] string callerMemberName = "")
         {
-            if (errorCode <= 0)
-            {
-                errorCode = -errorCode;
+            var message_combined = GetErrorString(context, errorCode, callerMemberName);
 
-                // message_managed
-                var message_managed = ErrorMessage.ResourceManager.GetString($"Native_0x{ errorCode.ToString("X4") }");
-
-                if (string.IsNullOrWhiteSpace(message_managed))
-                    message_managed = ErrorMessage.Native_0xFFFF;
-
-                // message_SOEM
-                var message_SOEM = string.Empty;
-
-                while (EcHL.HasEcError(context))
-                {
-                    if (!string.IsNullOrWhiteSpace(message_SOEM))
-                        message_SOEM += "\n";
-
-                    message_SOEM += Marshal.PtrToStringAnsi(EcHL.GetNextError(context));
-                }
-
-                // message_combined
-                var message_combined = $"{ callerMemberName } failed (0x{ errorCode.ToString("X4") }): { message_managed }";
-
-                if (!string.IsNullOrWhiteSpace(message_SOEM))
-                    message_combined += $"\n\nEtherCAT message:\n\n{ message_SOEM }";
-
+            if (message_combined != string.Empty)
                 throw new Exception(message_combined);
-            }
         }
 
         public static Dictionary<string, string> GetAvailableNetworkInterfaces()
@@ -277,7 +311,7 @@ namespace EtherCAT.NET
             return newRootSlave;
         }
 
-        public static SlaveInfo ScanDevices(string interfaceName, SlaveInfo referenceRootSlave = null)
+        public static SlaveInfo ScanDevices(string interfaceName, SlaveInfo referenceRootSlave = null, ILogger logger = null)
         {
             var nic = NetworkInterface.GetAllNetworkInterfaces().Where(x => x.Name == interfaceName).FirstOrDefault();
 
@@ -288,7 +322,7 @@ namespace EtherCAT.NET
                 throw new Exception($"The network interface '{interfaceName}' is not linked. Aborting action.");
 
             var context = EcHL.CreateContext();
-            var rootSlave = EcUtilities.ScanDevices(context, interfaceName, referenceRootSlave);
+            var rootSlave = EcUtilities.ScanDevices(context, interfaceName, referenceRootSlave, logger);
             EcHL.FreeContext(context);
 
             return rootSlave;
@@ -308,7 +342,7 @@ namespace EtherCAT.NET
         /// </summary>
         /// <param name="interfaceName">The name of the network adapter.</param>
         /// <returns>Returns found slave.</returns>
-        public static SlaveInfo ScanDevices(IntPtr context, string interfaceName, SlaveInfo referenceSlave = null)
+        public static SlaveInfo ScanDevices(IntPtr context, string interfaceName, SlaveInfo referenceSlave = null, ILogger logger = null)
         {
             ec_slave_info_t[] refSlaveIdentifications = null;
 
@@ -336,7 +370,15 @@ namespace EtherCAT.NET
             else
                 throw new PlatformNotSupportedException();
 
-            EcUtilities.CheckErrorCode(context, EcHL.ScanDevices(context, interfaceName, out var slaveIdentifications, out var slaveCount));
+            var errorString = EcUtilities.GetErrorString(context, EcHL.ScanDevices(context, interfaceName, out var slaveIdentifications, out var slaveCount));
+
+            if (errorString != string.Empty)
+            {
+                if (logger != null)
+                    DumpALStatus(context, logger);
+
+                throw new Exception(errorString);
+            }
 
             // create slaveInfo from received data
             var offset = 0;
@@ -355,6 +397,14 @@ namespace EtherCAT.NET
             }
 
             return EcUtilities.ToSlaveInfo(newSlaveIdentifications);
+        }
+
+        public static void DumpALStatus(IntPtr ctx, ILogger logger)
+        {
+            void cb(int slave, ushort state, ushort al, string name) =>
+                 logger.LogInformation("Slave {Slave} ({Name}): state=0x{State:X2} AL=0x{AL:X4}", slave, name, state, al);
+
+            EcHL.ALStatusForEachSlave(ctx, cb);
         }
 
         public static SlavePdo[] UploadPdoConfig(IntPtr context, UInt16 slave, UInt16 smIndex)

--- a/src/EtherCAT.NET/EcUtilities.cs
+++ b/src/EtherCAT.NET/EcUtilities.cs
@@ -295,6 +295,15 @@ namespace EtherCAT.NET
         }
 
         /// <summary>
+        /// Disables ACK flag in order to check if slaves have reached preop state.
+        /// </summary>
+        /// <param name="ackEnabled">Flag if ack check is enabled.</param>
+        public static void EnablePreopAckCheck(bool ackEnabled)
+        {
+            EcHL.EnablePreopAckCheck(ackEnabled);
+        }
+
+        /// <summary>
         /// Initializes EtherCAT and returns found slaves. 
         /// </summary>
         /// <param name="interfaceName">The name of the network adapter.</param>

--- a/src/EtherCAT.NET/EsiUtilities.cs
+++ b/src/EtherCAT.NET/EsiUtilities.cs
@@ -243,7 +243,9 @@ namespace EtherCAT.NET
 
         public static long ParseHexDecString(string value)
         {
-            if (value.StartsWith("#x"))
+            if (value == null)
+                return 0;
+            else if (value.StartsWith("#x"))
                 return uint.Parse(value.Replace("#x", string.Empty), NumberStyles.HexNumber);
             else
                 return long.Parse(value);

--- a/src/EtherCAT.NET/Infrastructure/DigitalOut.cs
+++ b/src/EtherCAT.NET/Infrastructure/DigitalOut.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace EtherCAT.NET.Infrastructure
 {
@@ -16,6 +17,41 @@ namespace EtherCAT.NET.Infrastructure
         {
             //
         }
+        
+        /// <summary>
+        /// Gets the Index of Matching Slave Variable Channel.
+        /// </summary>
+        /// <param name="channel"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentOutOfRangeException"></exception>
+        private (int bitOffset, IntPtr memptr) GetChannelInfo(int channel)
+        {
+            // Calculate total number of variables
+            int totalVariables = _slavePdos.Sum(pdo => pdo.Variables.Count);
+            if (channel < 1 || channel > totalVariables)
+            {
+                throw new ArgumentOutOfRangeException(nameof(channel), "Channel is out of range.");
+            }
+
+            int remainingChannels = channel - 1;
+            int pdoIndex = 0;
+
+            // Find the appropriate PDO and variable index
+            while (remainingChannels >= _slavePdos[pdoIndex].Variables.Count)
+            {
+                remainingChannels -= _slavePdos[pdoIndex].Variables.Count;
+                pdoIndex++;
+            }
+
+            int variableIndex = remainingChannels;
+
+            var pdo = _slavePdos[pdoIndex];
+            var variable = pdo.Variables[variableIndex];
+            var bitOffset = variable.BitOffset;
+            var memptr = new IntPtr((void*)variable.DataPtr);
+            
+            return (bitOffset, memptr);
+        }
 
         /// <summary>
         /// Sets digital output value for a specific channel. 
@@ -25,25 +61,19 @@ namespace EtherCAT.NET.Infrastructure
         /// <returns></returns>
         public bool SetChannel(int channel, bool value)
         {
-            var validChannel = ValidateChannel(channel);
+            var (bitOffset, memptr) = GetChannelInfo(channel);
 
-            if (validChannel)
-            {
-                // get slave variable in order to set bit offset
-                var slaveVariable = _slavePdos[channel - 1].Variables.First();
-                var bitOffset = slaveVariable.BitOffset;
-                var memptr = (int*)slaveVariable.DataPtr;
+            int* memptrInt = (int*)memptr.ToPointer();
 
-                if (value)
-                    // set channel bit
-                    memptr[0] |= 1 << bitOffset;
+            
+            if (value)
+                // set channel bit
+                memptrInt[0] |= 1 << bitOffset;
+            else
+                // clear channel bit
+                memptrInt[0] &= ~(1 << bitOffset);
 
-                else
-                    // clear channel bit
-                    memptr[0] &= ~(1 << bitOffset);  
-            }
-
-            return validChannel;
+            return true;
         }
 
         /// <summary>
@@ -53,18 +83,14 @@ namespace EtherCAT.NET.Infrastructure
         /// <returns></returns>
         public bool ToggleChannel(int channel)
         {
-            var validChannel = ValidateChannel(channel);
+            var (bitOffset, memptr) = GetChannelInfo(channel);
 
-            if (validChannel)
-            {
-                // get slave variable in order to set bit offset
-                var slaveVariable = _slavePdos[channel - 1].Variables.First();
-                var memptr = (int*)slaveVariable.DataPtr;
+            int* memptrInt = (int*)memptr.ToPointer();
 
-                memptr[0] ^= 1 << slaveVariable.BitOffset;
-            }
+            // Toggle channel bit
+            memptrInt[0] ^= 1 << bitOffset;
 
-            return validChannel;
+            return true;
         }
     }
 }

--- a/src/EtherCAT.NET/Infrastructure/SlaveInfo.cs
+++ b/src/EtherCAT.NET/Infrastructure/SlaveInfo.cs
@@ -58,6 +58,8 @@ namespace EtherCAT.NET.Infrastructure
 
         public SlaveInfoDynamicData DynamicData { get; set; }
 
+        public bool IgnoreSMConfig { get; set; } = false;
+
         #endregion
 
         #region "Methods"
@@ -103,8 +105,9 @@ namespace EtherCAT.NET.Infrastructure
         public IEnumerable<SdoWriteRequest> GetConfiguration(IEnumerable<SlaveExtension> slaveExtensions)
         {
             _slaveExtensions = slaveExtensions.ToList();
+            IEnumerable<SdoWriteRequest> configuration = this.GetSdoConfiguration().Concat(this.GetPdoConfiguration());
 
-            return this.GetSdoConfiguration().Concat(this.GetPdoConfiguration()).Concat(this.GetSmConfiguration());
+            return IgnoreSMConfig ? configuration : configuration.Concat(this.GetSmConfiguration());
         }
 
         private IEnumerable<SdoWriteRequest> GetSdoConfiguration()

--- a/src/EtherCAT.NET/Resources/ErrorMessage.Designer.cs
+++ b/src/EtherCAT.NET/Resources/ErrorMessage.Designer.cs
@@ -19,7 +19,7 @@ namespace EtherCAT {
     // -Klasse über ein Tool wie ResGen oder Visual Studio automatisch generiert.
     // Um einen Member hinzuzufügen oder zu entfernen, bearbeiten Sie die .ResX-Datei und führen dann ResGen
     // mit der /str-Option erneut aus, oder Sie erstellen Ihr VS-Projekt neu.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ErrorMessage {
@@ -164,6 +164,15 @@ namespace EtherCAT {
         internal static string Native_0x0104 {
             get {
                 return ResourceManager.GetString("Native_0x0104", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Sucht eine lokalisierte Zeichenfolge, die Could not restore process data watchdog. ähnelt.
+        /// </summary>
+        internal static string Native_0x0105 {
+            get {
+                return ResourceManager.GetString("Native_0x0105", resourceCulture);
             }
         }
         

--- a/src/EtherCAT.NET/Resources/ErrorMessage.resx
+++ b/src/EtherCAT.NET/Resources/ErrorMessage.resx
@@ -236,4 +236,7 @@ Linux:
   <data name="SoemWrapper_NetworkInterfaceNotFound" xml:space="preserve">
     <value>The specified network interface could not be found.</value>
   </data>
+  <data name="Native_0x0105" xml:space="preserve">
+    <value>Could not restore process data watchdog.</value>
+  </data>
 </root>

--- a/src/SOEM.PInvoke/PInvoke/EcHL.cs
+++ b/src/SOEM.PInvoke/PInvoke/EcHL.cs
@@ -7,13 +7,17 @@ namespace SOEM.PInvoke
     public static class EcHL
     {
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate double PO2SOCallback(UInt16 slaveIndex);
+        public delegate int PO2SOCallback(UInt16 slaveIndex);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate int FOECallback(UInt16 slave, int packetnumber, int datasize);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void SerialRxCallback(UInt16 slave, IntPtr buffer, int datasize);
+
+        [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
+        public delegate void ALStatusCallback(int slave, ushort state, ushort alStatus, [MarshalAs(UnmanagedType.LPStr)] string name);
+
 
 
         #region "Helper"
@@ -139,6 +143,11 @@ namespace SOEM.PInvoke
         [SuppressUnmanagedCodeSecurity]
         [DllImport(EcShared.NATIVE_DLL_NAME)]
         public static extern int ConfigureSync01(IntPtr context, ushort slaveIndex, ref byte[] assignActivate, int assignActivateByteLength, uint cycleTime0, uint cycleTime1, int cycleShift);
+
+
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(EcShared.NATIVE_DLL_NAME)]
+        public static extern int ALStatusForEachSlave(IntPtr context, ALStatusCallback callback);
 
         /// <summary>
         /// Requests SAFE-OP state.
@@ -332,7 +341,7 @@ namespace SOEM.PInvoke
 
         [SuppressUnmanagedCodeSecurity]
         [DllImport(EcShared.NATIVE_DLL_NAME)]
-        public static extern void RegisterCallback(IntPtr context, UInt16 slaveIndex, [MarshalAs(UnmanagedType.FunctionPtr)]PO2SOCallback callback);
+        public static extern void RegisterCallback(IntPtr context, UInt16 slaveIndex, IntPtr pCallBack);
 
         #endregion
 

--- a/src/SOEM.PInvoke/PInvoke/EcHL.cs
+++ b/src/SOEM.PInvoke/PInvoke/EcHL.cs
@@ -13,7 +13,7 @@ namespace SOEM.PInvoke
         public delegate int FOECallback(UInt16 slave, int packetnumber, int datasize);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
-        public delegate void SerialRxCallback(UInt16 slave, IntPtr buffer, int datasize);
+        public delegate void SerialRxCallback(UInt16 slave, IntPtr buffer, int datasize, bool rxFifoFull);
 
         [UnmanagedFunctionPointer(CallingConvention.Cdecl)]
         public delegate void ALStatusCallback(int slave, ushort state, ushort alStatus, [MarshalAs(UnmanagedType.LPStr)] string name);
@@ -197,7 +197,7 @@ namespace SOEM.PInvoke
         /// <param name="length">The file length of firmware file.</param>
         /// <returns>Returns workcounter from last slave response.</returns>
         [SuppressUnmanagedCodeSecurity]
-        [DllImport(EcShared.NATIVE_DLL_NAME)] 
+        [DllImport(EcShared.NATIVE_DLL_NAME)]
         public static extern int DownloadFirmware(IntPtr context, int slaveIndex, string fileName, int length);
 
 
@@ -291,10 +291,11 @@ namespace SOEM.PInvoke
         /// Initialize serial handshake processing for slave device.
         /// </summary>
         /// <param name="slaveIndex">The index of the corresponding slave.</param>
+        /// <param name="multibyteCtrlStatus">True if both tx control and rx status registers are multi-byte.</param>
         /// <returns>True if initialization was successful, false otherwise.</returns>
         [SuppressUnmanagedCodeSecurity]
         [DllImport(EcShared.NATIVE_DLL_NAME)]
-        public static extern bool InitSerial(int slaveIndex);
+        public static extern bool InitSerial(int slaveIndex, bool multibyteCtrlStatus);
 
         /// <summary>
         /// Close serial handshake processing for slave device.
@@ -331,6 +332,16 @@ namespace SOEM.PInvoke
         [SuppressUnmanagedCodeSecurity]
         [DllImport(EcShared.NATIVE_DLL_NAME)]
         public static extern void UpdateSerialIo(IntPtr context, int slaveIndex);
+
+        /// <summary>
+        /// Update serial handshake processing for standard slave device.
+        /// </summary>
+        /// <param name="slaveIndex">The index of the corresponding slave.</param>
+        /// <param name="input">Input process buffer.</param>
+        /// <param name="output">Output process buffer.</param>
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(EcShared.NATIVE_DLL_NAME)]
+        public static extern void UpdateSerialIoStandard(int slaveIndex, IntPtr input, IntPtr output);
 
         /// <summary>
         /// Returns process data for slave device.

--- a/src/SOEM.PInvoke/PInvoke/EcHL.cs
+++ b/src/SOEM.PInvoke/PInvoke/EcHL.cs
@@ -94,6 +94,17 @@ namespace SOEM.PInvoke
         public static extern int SdoWrite(IntPtr context, UInt16 slaveIndex, UInt16 sdoIndex, byte sdoSubIndex, byte[] dataset, UInt32 datasetCount, Int32[] byteCounts);
 
         /// <summary>
+        /// Checks if a sdo entry with index and sub index exists.
+        /// </summary>
+        /// <param name="slaveIndex">The index of the corresponding slave.</param>
+        /// <param name="sdoIndex">The index of the service data object.</param>
+        /// <param name="sdoSubindex">The sub index of the service data object.</param>
+        /// <returns>Returns true if the sdo entry for the slave exits, false otherwise.</returns>
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(EcShared.NATIVE_DLL_NAME)]
+        public static extern bool SdoEntryExists(IntPtr context, ushort slaveIndex, ushort sdoIndex, ushort sdoSubindex);
+
+        /// <summary>
         /// Reads service data object data from the mailbox of the corresponding slave.
         /// NoCa means the CA parameter of the native SOEM ecx_SDOread is set to false.
         /// CA = false: single subindex read. CA = true: Complete Access, all subindexes read.

--- a/src/SOEM.PInvoke/PInvoke/EcHL.cs
+++ b/src/SOEM.PInvoke/PInvoke/EcHL.cs
@@ -338,6 +338,10 @@ namespace SOEM.PInvoke
 
         #region "called during OP"
 
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(EcShared.NATIVE_DLL_NAME)]
+        public static extern int RestoreProcessDataWatchdog(IntPtr context);
+
         /// <summary>
         /// Sends a frame to distribute new output process data and waits for return of this frame to receive input process data.
         /// </summary>

--- a/src/SOEM.PInvoke/PInvoke/EcHL.cs
+++ b/src/SOEM.PInvoke/PInvoke/EcHL.cs
@@ -47,6 +47,14 @@ namespace SOEM.PInvoke
         #region "called before OP"
 
         /// <summary>
+        /// Disables ACK flag in order to check if slaves have reached preop state.
+        /// </summary>
+        /// <param name="ackEnabled">Flag if ack check is enabled.</param>
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(EcShared.NATIVE_DLL_NAME)]
+        public static extern int EnablePreopAckCheck(bool ackEnabled);
+
+        /// <summary>
         /// Initializes EtherCAT and scans for connected slaves.
         /// </summary>
         /// <param name="networkInterfaceName">The name of the network interface which is connected to the EtherCAT network.</param>
@@ -303,6 +311,16 @@ namespace SOEM.PInvoke
         [SuppressUnmanagedCodeSecurity]
         [DllImport(EcShared.NATIVE_DLL_NAME)]
         public static extern void UpdateSerialIo(IntPtr context, int slaveIndex);
+
+        /// <summary>
+        /// Returns process data for slave device.
+        /// </summary>
+        /// <param name="slaveIndex">The index of the corresponding slave.</param>
+        /// <param name="output">Output buffer.</param>
+        /// <param name="input">Input buffer.</param>
+        [SuppressUnmanagedCodeSecurity]
+        [DllImport(EcShared.NATIVE_DLL_NAME)]
+        public static extern void GetProcessIo(IntPtr context, int slaveIndex, out IntPtr output, out IntPtr input);
 
         /// <summary>
         /// Request specific state for all slaves.

--- a/src/SOEM.PInvoke/SOEM.PInvoke.csproj
+++ b/src/SOEM.PInvoke/SOEM.PInvoke.csproj
@@ -8,9 +8,22 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <IsWindows>False</IsWindows>
+    <IsLinux>False</IsLinux>
+    <IsLinuxArm>False</IsLinuxArm>
+    <IsPublicBuild>False</IsPublicBuild>
     <IsWindows Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' == 'True'">True</IsWindows>
     <IsLinux Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Linux)))' == 'True'">True</IsLinux>
+    <ProcessArchitecture>$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)</ProcessArchitecture>
+    <IsLinuxArm Condition="'$(IsLinux)' == 'True' And ('$(ProcessArchitecture)' == 'Arm' Or '$(ProcessArchitecture)' == 'Arm64')">True</IsLinuxArm>
   </PropertyGroup>
+
+  <Target Name="DumpArchInfo" BeforeTargets="Build">
+    <Message Text="  IsWindows   = '$(IsWindows)'" Importance="High" />
+    <Message Text="  IsLinux     = '$(IsLinux)'" Importance="High" />
+    <Message Text="  IsLinuxArm  = '$(IsLinuxArm)'"  Importance="High" />
+    <Message Text="  ProcessArch = '$(ProcessArchitecture)'" Importance="High" />
+  </Target>
 
   <ItemGroup Condition="'$(IsPublicBuild)' == 'True'">
     <Content Include="./../../artifacts/bin32/SOEM_wrapper/Release/soem_wrapper.dll" Link="runtimes/win-x86/native/soem_wrapper.dll">
@@ -31,7 +44,7 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsPublicBuild)' == '' AND $(IsWindows) == 'True'">
+  <ItemGroup Condition="'$(IsPublicBuild)' == 'False' AND $(IsWindows) == 'True'">
     <Content Include="./../../artifacts/bin32/SOEM_wrapper/Release/soem_wrapper.dll" Link="runtimes/win-x86/native/soem_wrapper.dll">
       <PackagePath>runtimes/win-x86/native</PackagePath>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -42,13 +55,24 @@
     </Content>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsPublicBuild)' == '' AND $(IsLinux) == 'True'">
+  <ItemGroup Condition="'$(IsPublicBuild)' == 'False' AND $(IsLinux) == 'True' AND '$(IsLinuxArm)' != 'True'">
     <Content Include="./../../artifacts/bin32/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/linux-x86/native/libsoem_wrapper.so">
       <PackagePath>runtimes/linux-x86/native</PackagePath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
     <Content Include="./../../artifacts/bin64/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/linux-x64/native/libsoem_wrapper.so">
       <PackagePath>runtimes/linux-x64/native</PackagePath>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(IsPublicBuild)' == 'False' AND $(IsLinux) == 'True' AND '$(IsLinuxArm)' == 'True'">
+    <Content Include="./../../artifacts/arm32/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/arm/native/libsoem_wrapper.so">
+      <PackagePath>runtimes/arm/native</PackagePath>
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="./../../artifacts/arm64/SOEM_wrapper/libsoem_wrapper.so" Link="runtimes/arm64/native/libsoem_wrapper.so">
+      <PackagePath>runtimes/arm64/native</PackagePath>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
This merge request includes the following changes:

-  **Enable access to the slave’s I/O map for K-Bus mapping** 
Provide a function to expose a slave’s input/output process-data buffers to enable external K-Bus mapping, and introduce a helper that probes an SDO (index/subindex) to determine whether a K-Bus coupler table is present.

- **Configurable PRE-OP ACK handling**
Option to explicitly consider/ignore the ACK flag when verifying that a slave reached PRE-OP. Useful for devices that behave differently during transitions.

- **Process-data watchdog handling during init**
On master initialization, the process-data watchdog of each slave is temporarily set to 0 (disabled) and restored afterwards to avoid spurious WD trips while PDOs/SMs are being set up.

- **Fix for PDO assignment callback** 
On Linux the PDO assignment callback (PO2SOCallback) was garbage-collected before SOEM called it.

- **AL status logging** 
Add per-slave AL-status logging to simplify bring-up and failure analysis.

- **Serial Handshake Layer**
Improve serial handshake for serial terminals.